### PR TITLE
Merge back use case

### DIFF
--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -36,6 +36,7 @@ import { GithubCreateMilestoneUseCase } from './use-cases/create-milestone-use-c
 import { GithubMilestoneCreator } from './workers/milestone-creator';
 import { MarkdownKeepChangelogBuilder } from './workers/keep-changelog-builder/markdown-keep-changelog-builder';
 import { SlackKeepChangelogBuilder } from './workers/keep-changelog-builder/slack-keep-changelog-builder';
+import { GithubMergeBackUseCase } from './use-cases/merge-back-use-case';
 
 export class Dependencies
   implements
@@ -163,6 +164,12 @@ export class Dependencies
     this.config.pullRequestTitlePrefix,
     this.config.jiraProjectName,
     this.config.confirmationEmoji
+  );
+
+  mergeBackUseCase = new GithubMergeBackUseCase(
+    this.config.githubOwner,
+    this.pullRequestCreator,
+    this.githubService
   );
 
   project = this.config.jiraProjectName;

--- a/src/use-cases/merge-back-use-case.ts
+++ b/src/use-cases/merge-back-use-case.ts
@@ -71,7 +71,7 @@ export class GithubMergeBackUseCase implements MergeBackUseCase {
       .compareCommits(this.owner, input.repository, input.head, input.base)
       .pipe(
         switchMap((response) => {
-          if (response.ahead_by > 0) {
+          if (response.aheadBy > 0) {
             return this.pullRequestCreator
               .create(
                 `Merge back ${input.head} -> ${input.base}`,

--- a/src/use-cases/merge-back-use-case.ts
+++ b/src/use-cases/merge-back-use-case.ts
@@ -1,0 +1,135 @@
+import { PullsMergeResponseData } from '@octokit/types';
+import { Observable, of } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { GithubService, PullRequestData } from '../services/github-service';
+import { GithubPullRequestCreator } from '../workers/pull-request-creator';
+
+export interface MergeBackUseCase {
+  execute(input: MergeBackUseCaseInput): Observable<MergeBackUseCaseOutput>;
+}
+
+export interface MergeBackUseCaseInput {
+  readonly head: string;
+  readonly base: string;
+  readonly repository: string;
+}
+
+export type MergeBackUseCaseOutput =
+  | SuccessMergeBackUseCaseOutput
+  | FailedToMergeMergeBackUseCaseOutput
+  | NoMergeNeededMergeMergeBackUseCaseOutput
+  | NotMergeableMergeMergeBackUseCaseOutput;
+export type KnownMergeBackUseCaseOutputType =
+  | 'SUCCESS'
+  | 'FAILED_TO_MERGE'
+  | 'NO_MERGE_NEEDED'
+  | 'NOT_MERGEABLE';
+export interface MergeBackUseCaseOutputType {
+  type: KnownMergeBackUseCaseOutputType;
+}
+
+export interface SuccessMergeBackUseCaseOutput
+  extends MergeBackUseCaseOutputType {
+  type: 'SUCCESS';
+  pullRequestData: PullRequestData;
+}
+
+export interface FailedToMergeMergeBackUseCaseOutput
+  extends MergeBackUseCaseOutputType {
+  type: 'FAILED_TO_MERGE';
+  pullRequestData: PullRequestData;
+}
+
+export interface NoMergeNeededMergeMergeBackUseCaseOutput
+  extends MergeBackUseCaseOutputType {
+  type: 'NO_MERGE_NEEDED';
+}
+
+export interface NotMergeableMergeMergeBackUseCaseOutput
+  extends MergeBackUseCaseOutputType {
+  type: 'NOT_MERGEABLE';
+  pullRequestData: PullRequestData;
+}
+
+export class GithubMergeBackUseCase implements MergeBackUseCase {
+  private readonly pullRequestCreator: GithubPullRequestCreator;
+  private readonly githubService: GithubService;
+  private readonly owner: string;
+
+  constructor(
+    owner: string,
+    pullRequestCreator: GithubPullRequestCreator,
+    githubService: GithubService
+  ) {
+    this.owner = owner;
+    this.pullRequestCreator = pullRequestCreator;
+    this.githubService = githubService;
+  }
+
+  execute(input: MergeBackUseCaseInput): Observable<MergeBackUseCaseOutput> {
+    return this.githubService
+      .compareCommits(this.owner, input.repository, input.head, input.base)
+      .pipe(
+        switchMap((response) => {
+          if (response.ahead_by > 0) {
+            return this.pullRequestCreator
+              .create(
+                `Merge back ${input.head} -> ${input.base}`,
+                input.head,
+                input.base,
+                input.repository
+              )
+              .pipe(
+                switchMap((pullRequestOutput) =>
+                  this.githubService
+                    .pullRequestData(
+                      this.owner,
+                      input.repository,
+                      pullRequestOutput.pullRequestNumber
+                    )
+                    .pipe(
+                      switchMap((pullRequestData) => {
+                        if (pullRequestData.mergeable) {
+                          return this.githubService
+                            .merge(
+                              this.owner,
+                              input.repository,
+                              pullRequestOutput.pullRequestNumber
+                            )
+                            .pipe(
+                              switchMap((mergeResponse) => {
+                                const merged = (mergeResponse as PullsMergeResponseData)
+                                  .merged;
+                                if (merged) {
+                                  const result: SuccessMergeBackUseCaseOutput = {
+                                    type: 'SUCCESS',
+                                    pullRequestData: pullRequestData
+                                  };
+                                  return of(result);
+                                }
+                                const result: FailedToMergeMergeBackUseCaseOutput = {
+                                  type: 'FAILED_TO_MERGE',
+                                  pullRequestData: pullRequestData
+                                };
+                                return of(result);
+                              })
+                            );
+                        }
+                        const result: NotMergeableMergeMergeBackUseCaseOutput = {
+                          type: 'NOT_MERGEABLE',
+                          pullRequestData: pullRequestData
+                        };
+                        return of(result);
+                      })
+                    )
+                )
+              );
+          }
+          const result: NoMergeNeededMergeMergeBackUseCaseOutput = {
+            type: 'NO_MERGE_NEEDED'
+          };
+          return of(result);
+        })
+      );
+  }
+}

--- a/src/workers/jira-ticket-parser.ts
+++ b/src/workers/jira-ticket-parser.ts
@@ -10,7 +10,8 @@ export class ConcreteJiraTickerParser implements JiraTicketParser {
       .map((x) => x.match(regex))
       .map((x) => (x == null ? [] : x))
       .filter((x) => x.length > 0)
-      .map((x) => x.map((y) => y.replace('[', '').replace(']', ''))).reduce((acc, x) => acc.concat(x), []);
+      .map((x) => x.map((y) => y.replace('[', '').replace(']', '')))
+      .reduce((acc, x) => acc.concat(x), []);
 
     return Array.from(new Set(extractedTicketIds));
   }

--- a/src/workers/jira-ticket-parser.ts
+++ b/src/workers/jira-ticket-parser.ts
@@ -4,7 +4,7 @@ export interface JiraTicketParser {
 
 export class ConcreteJiraTickerParser implements JiraTicketParser {
   parse(values: string[]): string[] {
-    const regex = /(PSF-\d+)/g;
+    const regex = /((?!([A-Z0-9a-z]{1,10})-?$)[A-Z]{1}[A-Z0-9]+-\d+)/g;
 
     const extractedTicketIds = values
       .map((x) => x.match(regex))

--- a/tests/mocks/github-service-mock.ts
+++ b/tests/mocks/github-service-mock.ts
@@ -1,0 +1,80 @@
+import { of } from 'rxjs';
+import { instance, mock, when } from 'ts-mockito';
+import { GithubService } from '../../src/services/github-service';
+
+export class GithubServiceMock {
+  readonly owner: string;
+  readonly repo: string;
+  readonly githubService: GithubService;
+
+  constructor(owner: string, repo: string) {
+    this.owner = owner;
+    this.repo = repo;
+    this.githubService = mock<GithubService>();
+  }
+
+  build(): GithubService {
+    return instance(this.githubService);
+  }
+
+  unmergeablePR(pullNumber: number): GithubServiceMock {
+    when(
+      this.githubService.pullRequestData(this.owner, this.repo, pullNumber)
+    ).thenReturn(
+      of({
+        number: 123,
+        login: 'login',
+        description: 'description',
+        mergedAt: '2021-02-01',
+        url: 'www.pudim.com.br',
+        authorImageUrl: 'www.image.com',
+        mergeable: false
+      })
+    );
+
+    return this;
+  }
+
+  mergeablePR(pullNumber: number): GithubServiceMock {
+    when(
+      this.githubService.pullRequestData(this.owner, this.repo, pullNumber)
+    ).thenReturn(
+      of({
+        number: 123,
+        login: 'login',
+        description: 'description',
+        mergedAt: '2021-02-01',
+        url: 'www.pudim.com.br',
+        authorImageUrl: 'www.image.com',
+        mergeable: true
+      })
+    );
+
+    return this;
+  }
+
+  mergeFailed(pullNumber: number): GithubServiceMock {
+    when(
+      this.githubService.merge(this.owner, this.repo, pullNumber)
+    ).thenReturn(of({ merged: false }));
+    return this;
+  }
+
+  mergeSucceeded(pullNumber: number): GithubServiceMock {
+    when(
+      this.githubService.merge(this.owner, this.repo, pullNumber)
+    ).thenReturn(of({ merged: true }));
+    return this;
+  }
+
+  compareAheadBy(
+    head: string,
+    base: string,
+    aheadBy: number
+  ): GithubServiceMock {
+    when(
+      this.githubService.compareCommits(this.owner, this.repo, head, base)
+    ).thenReturn(of({ aheadBy }));
+    return this;
+  }
+}

--- a/tests/mocks/mocks.ts
+++ b/tests/mocks/mocks.ts
@@ -1,0 +1,12 @@
+import { GithubServiceMock } from './github-service-mock';
+import { PullRequestCreatorMock } from './pull-request-creator-mock';
+
+export class Mocks {
+  static githubService(owner: string, repo: string): GithubServiceMock {
+    return new GithubServiceMock(owner, repo);
+  }
+
+  static githubPullRequestCreator(): PullRequestCreatorMock {
+    return new PullRequestCreatorMock();
+  }
+}

--- a/tests/mocks/pull-request-creator-mock.ts
+++ b/tests/mocks/pull-request-creator-mock.ts
@@ -1,0 +1,22 @@
+import { of } from 'rxjs';
+import { anyString, instance, mock, when } from 'ts-mockito';
+import { GithubPullRequestCreator } from '../../src/workers/pull-request-creator';
+
+export class PullRequestCreatorMock {
+  pullRequestCreator: GithubPullRequestCreator;
+
+  constructor() {
+    this.pullRequestCreator = mock<GithubPullRequestCreator>();
+  }
+
+  build(): GithubPullRequestCreator {
+    return instance(this.pullRequestCreator);
+  }
+
+  succesful(): PullRequestCreatorMock {
+    when(
+      this.pullRequestCreator.create(anyString(), 'head', 'base', 'repo')
+    ).thenReturn(of({ pullRequestNumber: 1, id: 1 }));
+    return this;
+  }
+}

--- a/tests/use-cases/merge-back-use-case.test.ts
+++ b/tests/use-cases/merge-back-use-case.test.ts
@@ -1,0 +1,128 @@
+import { GithubMergeBackUseCase } from '../../src/use-cases/merge-back-use-case';
+import { Mocks } from '../mocks/mocks';
+
+describe('the merge back use case', () => {
+  describe('given an release brach ahead of base', () => {
+    describe('given an unmergeable PR', () => {
+      it('when executing then it returns not mergeable', (done) => {
+        const pullNumber = 1;
+        const aheadBy = 1;
+        const githubService = Mocks.githubService('owner', 'repo')
+          .compareAheadBy('head', 'base', aheadBy)
+          .unmergeablePR(pullNumber)
+          .build();
+        const pullRequestCreator = Mocks.githubPullRequestCreator()
+          .succesful()
+          .build();
+
+        const sut = new GithubMergeBackUseCase(
+          'owner',
+          pullRequestCreator,
+          githubService
+        );
+
+        sut
+          .execute({ head: 'head', base: 'base', repository: 'repo' })
+          .subscribe({
+            next: (response) => {
+              expect(response.type).toEqual('NOT_MERGEABLE');
+            },
+            error: fail,
+            complete: done
+          });
+      });
+    });
+
+    describe('given a mergeable PR', () => {
+      describe('given merge fails', () => {
+        it('when executing then it returns FAILED TO MERGE', (done) => {
+          const pullNumber = 1;
+          const aheadBy = 1;
+          const githubService = Mocks.githubService('owner', 'repo')
+            .compareAheadBy('head', 'base', aheadBy)
+            .mergeablePR(pullNumber)
+            .mergeFailed(pullNumber)
+            .build();
+          const pullRequestCreator = Mocks.githubPullRequestCreator()
+            .succesful()
+            .build();
+
+          const sut = new GithubMergeBackUseCase(
+            'owner',
+            pullRequestCreator,
+            githubService
+          );
+
+          sut
+            .execute({ head: 'head', base: 'base', repository: 'repo' })
+            .subscribe({
+              next: (response) => {
+                expect(response.type).toEqual('FAILED_TO_MERGE');
+              },
+              error: fail,
+              complete: done
+            });
+        });
+      });
+
+      describe('given merge succeeds', () => {
+        it('when executing then it returns SUCCESS', (done) => {
+          const pullNumber = 1;
+          const aheadBy = 1;
+          const githubService = Mocks.githubService('owner', 'repo')
+            .compareAheadBy('head', 'base', aheadBy)
+            .mergeablePR(pullNumber)
+            .mergeSucceeded(pullNumber)
+            .build();
+          const pullRequestCreator = Mocks.githubPullRequestCreator()
+            .succesful()
+            .build();
+
+          const sut = new GithubMergeBackUseCase(
+            'owner',
+            pullRequestCreator,
+            githubService
+          );
+
+          sut
+            .execute({ head: 'head', base: 'base', repository: 'repo' })
+            .subscribe({
+              next: (response) => {
+                expect(response.type).toEqual('SUCCESS');
+              },
+              error: fail,
+              complete: done
+            });
+        });
+      });
+    });
+  });
+
+  describe('given an release brach at same level of base', () => {
+    it('when executing then it returns NO_MERGE_NEEDED', (done) => {
+      const aheadBy = 0;
+      const githubService = Mocks.githubService('owner', 'repo')
+        .compareAheadBy('head', 'base', aheadBy)
+        .build();
+      const pullRequestCreator = Mocks.githubPullRequestCreator()
+        .succesful()
+        .build();
+
+      const sut = new GithubMergeBackUseCase(
+        'owner',
+        pullRequestCreator,
+        githubService
+      );
+
+      sut
+        .execute({ head: 'head', base: 'base', repository: 'repo' })
+        .subscribe({
+          next: (response) => {
+            expect(response.type).toEqual('NO_MERGE_NEEDED');
+          },
+          error: fail,
+          complete: done
+        });
+    });
+  });
+});

--- a/tests/use-cases/read-pull-request-info-use-case.test.ts
+++ b/tests/use-cases/read-pull-request-info-use-case.test.ts
@@ -15,7 +15,8 @@ describe('The read pull request info use case', () => {
         description: 'description',
         mergedAt: 'mergedAt',
         url: 'www.pudim.com.br',
-        authorImageUrl: 'www.image.com'
+        authorImageUrl: 'www.image.com',
+        mergeable: true
       })
     );
 
@@ -49,7 +50,8 @@ describe('The read pull request info use case', () => {
           description: 'description',
           mergedAt: 'mergedAt',
           url: 'www.pudim.com.br',
-          authorImageUrl: 'www.image.com'
+          authorImageUrl: 'www.image.com',
+          mergeable: true
         })
       );
 

--- a/tests/workers/jira-ticket-parser.test.ts
+++ b/tests/workers/jira-ticket-parser.test.ts
@@ -7,7 +7,9 @@ describe('The jira ticket parser', () => {
   });
 
   it('works with number tags', () => {
-    expect(sut.parse(['[PSF-123][PSF-456] [PSF-78910] Bla Bla'])).toStrictEqual(['PSF-123', 'PSF-456', 'PSF-78910']);
+    expect(
+      sut.parse(['[PSF-123][PSF-456] [PSF-78910] Bla Bla'])
+    ).toStrictEqual(['PSF-123', 'PSF-456', 'PSF-78910']);
   });
 
   it('does not work with number tags', () => {


### PR DESCRIPTION
With this PR, I implement the Merge Back use case.

The merge back use case compares a head and a base, checks if there are commits ahead of it, opens a pull request with a merge request between the two, and merges if no conflicts.

This use case will be useful when closing releases automatically.