### PR TITLE
Release version in Jira across multiple projects

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import { StartTrainEndpoint } from './endpoints/start-train-endpoint';
 import swagger from 'swagger-ui-express';
 import * as swaggerDocument from '../swagger.json';
 import { UpdateReleaseEndpoint } from './endpoints/update-release-endpoint';
+import { ReleaseVersionEndpoint } from './endpoints/release-version-endpoint';
 
 const app = express();
 app.use(bodyParser.json());
@@ -49,6 +50,16 @@ app.post('/startTrain', (req, res) => {
 
 app.post('/updateRelease', (req, res) => {
   new UpdateReleaseEndpoint(dependencies).execute(req.body).subscribe(
+    (x) => res.send(x),
+    (error) => {
+      console.log(error);
+      res.send(error);
+    }
+  );
+});
+
+app.post('/releaseVersion', (req, res) => {
+  new ReleaseVersionEndpoint(dependencies).execute(req.body).subscribe(
     (x) => res.send(x),
     (error) => {
       console.log(error);

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -15,7 +15,7 @@ import { GithubCreateBranchUseCase } from './use-cases/create-branch-use-case';
 import { GithubSHAFinder } from './workers/sha-finder';
 import { GithubBranchCreator } from './workers/branch-creator';
 import { GithubPullRequestCreator } from './workers/pull-request-creator';
-import { StartTrainDependencies } from './endpoints/start-train-endpoint';
+import { StartTrainEndpointDependencies } from './endpoints/start-train-endpoint';
 import { StartTrainUseCase } from './use-cases/start-train-use-case';
 import { SlackMessageSender } from './workers/message-sender';
 import { WebClient } from '@slack/web-api';
@@ -40,12 +40,15 @@ import { ConcreteExtractTicketsUseCase } from './use-cases/extract-tickets-use-c
 import { ConcreteCommitPRNumberParser } from './workers/keep-changelog-builder/commits-pr-number-parser';
 import { ConcreteUpdateReleaseUseCase } from './use-cases/update-release-use-case';
 import { GithubDraftReleaseGuesser } from './workers/github-draft-release-guesser';
+import { ReleaseVersionEndpointDependencies } from './endpoints/release-version-endpoint';
+import { ReleaseVersionUseCase } from './use-cases/release-version-use-case';
 
 export class Dependencies
   implements
     TagEndpointDependencies,
     CreateReleaseEndpointDependencies,
-    StartTrainDependencies {
+    ReleaseVersionEndpointDependencies,
+    StartTrainEndpointDependencies {
   keychain = new Keychain(process.env);
   config = new Config();
 
@@ -161,6 +164,8 @@ export class Dependencies
     this.messageSender,
     this.createMilestoneUseCase
   );
+
+  releaseVersionUseCase = new ReleaseVersionUseCase(this.jiraService);
 
   reactionsReader = new SlackReactionsReader(this.slackWebClient);
   nextReleaseGuesser = new GithubDraftReleaseGuesser(

--- a/src/endpoints/release-version-endpoint.ts
+++ b/src/endpoints/release-version-endpoint.ts
@@ -1,0 +1,36 @@
+import { ReleaseVersionUseCase } from '../use-cases/release-version-use-case';
+import { mapTo } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+
+export interface ReleaseVersionEndpointInput {
+  readonly tag: string;
+  readonly projectKeys: string[];
+  readonly jiraTagSuffix: string;
+  readonly releaseDate?: string;
+}
+
+export class ReleaseVersionEndpointOutput {}
+
+export interface ReleaseVersionEndpointDependencies {
+  releaseVersionUseCase: ReleaseVersionUseCase;
+}
+
+export class ReleaseVersionEndpoint {
+  private releaseVersionUseCase: ReleaseVersionUseCase;
+
+  constructor(dependencies: ReleaseVersionEndpointDependencies) {
+    this.releaseVersionUseCase = dependencies.releaseVersionUseCase;
+  }
+
+  execute(
+    input: ReleaseVersionEndpointInput
+  ): Observable<ReleaseVersionEndpointOutput> {
+    return this.releaseVersionUseCase
+      .execute({
+        projectKeys: input.projectKeys,
+        version: `${input.tag}${input.jiraTagSuffix}`,
+        releaseDate: input.releaseDate
+      })
+      .pipe(mapTo(new ReleaseVersionEndpointOutput()));
+  }
+}

--- a/src/endpoints/start-train-endpoint.ts
+++ b/src/endpoints/start-train-endpoint.ts
@@ -3,7 +3,7 @@ import { StartTrainUseCase } from '../use-cases/start-train-use-case';
 import { map } from 'rxjs/operators';
 import { ReleaseType } from '../workers/next-release-guesser';
 
-export interface StartTrainDependencies {
+export interface StartTrainEndpointDependencies {
   readonly startTrainUseCase: StartTrainUseCase;
 }
 
@@ -24,7 +24,7 @@ export class StartTrainEndpointOutput {}
 export class StartTrainEndpoint {
   private startTrainUseCase: StartTrainUseCase;
 
-  constructor(dependencies: StartTrainDependencies) {
+  constructor(dependencies: StartTrainEndpointDependencies) {
     this.startTrainUseCase = dependencies.startTrainUseCase;
   }
 

--- a/src/typings/jira-client/index.d.ts
+++ b/src/typings/jira-client/index.d.ts
@@ -436,6 +436,8 @@ declare module 'jira-client' {
       id: string;
       name: string;
       projectId: number;
+      released?: boolean;
+      releaseDate?: string;
     }
 
     interface SearchQuery {

--- a/src/use-cases/release-version-use-case.ts
+++ b/src/use-cases/release-version-use-case.ts
@@ -1,0 +1,36 @@
+import { forkJoin, Observable } from 'rxjs';
+import { mapTo } from 'rxjs/operators';
+import { JiraService } from '../services/jira-service';
+
+export class ReleaseVersionUseCaseInput {
+  constructor(
+    readonly projectKeys: string[],
+    readonly version: string,
+    readonly releaseDate?: string
+  ) {}
+}
+
+export class ReleaseVersionUseCaseOutput {}
+
+export class ReleaseVersionUseCase {
+  constructor(readonly jiraService: JiraService) {}
+
+  execute(
+    input: ReleaseVersionUseCaseInput
+  ): Observable<ReleaseVersionUseCaseOutput[]> {
+    const releaseVersions = input.projectKeys.map((projectKey) => {
+      return this.releaseVersion(projectKey, input.version, input.releaseDate);
+    });
+    return forkJoin(releaseVersions);
+  }
+
+  private releaseVersion(
+    projectKey: string,
+    version: string,
+    releaseDate?: string
+  ): Observable<ReleaseVersionUseCaseOutput> {
+    return this.jiraService
+      .releaseVersion(version, projectKey, releaseDate)
+      .pipe(mapTo(new ReleaseVersionUseCaseOutput()));
+  }
+}

--- a/swagger.json
+++ b/swagger.json
@@ -233,7 +233,7 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "projectTag": {
+                  "tag": {
                     "type": "string",
                     "example": "1.0.0"
                   },

--- a/swagger.json
+++ b/swagger.json
@@ -223,6 +223,47 @@
           }
         }
       }
+    },
+    "/releaseVersion": {
+      "post": {
+        "description": "This endpoint releases a version in JIRA",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectTag": {
+                    "type": "string",
+                    "example": "1.0.0"
+                  },
+                  "projectKeys": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": ["ABC"]
+                  },
+                  "jiraTagSuffix": {
+                    "type": "string",
+                    "example": "-backend",
+                    "description": "This field will be concatenated as a suffix of the guessed next release"
+                  },
+                  "releaseDate": {
+                    "type": "string",
+                    "example": "(Optional) Date of the release, expressed in ISO 8601 format (yyyy-mm-dd). Defaults to current date."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   }
 }

--- a/tests/endpoints/endpoints.test.ts
+++ b/tests/endpoints/endpoints.test.ts
@@ -1,6 +1,6 @@
 import {
   StartTrainEndpoint,
-  StartTrainDependencies
+  StartTrainEndpointDependencies
 } from '../../src/endpoints/start-train-endpoint';
 import { mock, instance, when, anything, verify } from 'ts-mockito';
 import {
@@ -21,7 +21,8 @@ import {
 } from '../../src/endpoints/tag-endpoint';
 import { TagUseCase, TagUseCaseOutput } from '../../src/use-cases/tag-use-case';
 
-class TestStartTrainEndpointDependencies implements StartTrainDependencies {
+class TestStartTrainEndpointDependencies
+  implements StartTrainEndpointDependencies {
   startTrainUseCaseMock = mock<StartTrainUseCase>();
   startTrainUseCase = instance(this.startTrainUseCaseMock);
 }

--- a/tests/mocks/jira-service-mock.ts
+++ b/tests/mocks/jira-service-mock.ts
@@ -1,0 +1,38 @@
+import { of, throwError } from 'rxjs';
+import { instance, mock, when } from 'ts-mockito';
+import { JiraService } from '../../src/services/jira-service';
+
+export class JiraServiceMock {
+  mock: JiraService;
+
+  constructor() {
+    this.mock = mock<JiraService>();
+  }
+
+  build(): JiraService {
+    return instance(this.mock);
+  }
+
+  failingReleaseVersion(input: {
+    name: string;
+    projectKey: string;
+    releaseDate?: string | undefined;
+  }): JiraServiceMock {
+    when(
+      this.mock.releaseVersion(input.name, input.projectKey, input.releaseDate)
+    ).thenReturn(throwError('Unknown version'));
+
+    return this;
+  }
+
+  passingReleaseVersion(input: {
+    name: string;
+    projectKey: string;
+    releaseDate?: string | undefined;
+  }): JiraServiceMock {
+    when(
+      this.mock.releaseVersion(input.name, input.projectKey, input.releaseDate)
+    ).thenReturn(of(void 0));
+    return this;
+  }
+}

--- a/tests/mocks/mocks.ts
+++ b/tests/mocks/mocks.ts
@@ -1,4 +1,5 @@
 import { GithubServiceMock } from './github-service-mock';
+import { JiraServiceMock } from './jira-service-mock';
 import { PullRequestCreatorMock } from './pull-request-creator-mock';
 
 export class Mocks {
@@ -8,5 +9,9 @@ export class Mocks {
 
   static githubPullRequestCreator(): PullRequestCreatorMock {
     return new PullRequestCreatorMock();
+  }
+
+  static jiraService(): JiraServiceMock {
+    return new JiraServiceMock();
   }
 }

--- a/tests/use-cases/release-version-use-case.test.ts
+++ b/tests/use-cases/release-version-use-case.test.ts
@@ -1,0 +1,118 @@
+import { anything, verify } from 'ts-mockito';
+import { JiraService } from '../../src/services/jira-service';
+import {
+  ReleaseVersionUseCase,
+  ReleaseVersionUseCaseInput
+} from '../../src/use-cases/release-version-use-case';
+import { JiraServiceMock } from '../mocks/jira-service-mock';
+import { Mocks } from '../mocks/mocks';
+
+describe('the release version use case', () => {
+  let jiraServiceMock: JiraServiceMock;
+
+  beforeEach(() => {
+    jiraServiceMock = Mocks.jiraService();
+  });
+
+  describe('with success jira service', () => {
+    let jiraService: JiraService;
+
+    beforeEach(() => {
+      jiraService = jiraServiceMock
+        .passingReleaseVersion({
+          name: '1.0.0',
+          projectKey: 'pass',
+          releaseDate: undefined
+        })
+        .build();
+    });
+
+    it('does not fail the use case', (done) => {
+      const sut = new ReleaseVersionUseCase(jiraService);
+      sut
+        .execute(new ReleaseVersionUseCaseInput(['pass'], '1.0.0', undefined))
+        .subscribe({
+          next: () => {
+            done();
+          },
+          error: () => {
+            fail();
+          }
+        });
+    });
+  });
+
+  describe('with failing jira service', () => {
+    let jiraService: JiraService;
+    beforeEach(() => {
+      jiraService = jiraServiceMock
+        .failingReleaseVersion({
+          name: 'version',
+          projectKey: 'projectKey',
+          releaseDate: 'releaseDate'
+        })
+        .build();
+    });
+
+    it('fails the use case', (done) => {
+      const sut = new ReleaseVersionUseCase(jiraService);
+      sut
+        .execute(
+          new ReleaseVersionUseCaseInput(
+            ['projectKey'],
+            'version',
+            'releaseDate'
+          )
+        )
+        .subscribe({
+          next: () => {
+            fail();
+          },
+          error: () => {
+            done();
+          }
+        });
+    });
+  });
+
+  describe('with intermitent jira service', () => {
+    let jiraService: JiraService;
+    beforeEach(() => {
+      jiraService = jiraServiceMock
+        .failingReleaseVersion({
+          name: '1.0.0',
+          projectKey: 'fail',
+          releaseDate: undefined
+        })
+        .passingReleaseVersion({
+          name: '1.0.0',
+          projectKey: 'pass',
+          releaseDate: undefined
+        })
+        .build();
+    });
+
+    it('fails the use case', (done) => {
+      const sut = new ReleaseVersionUseCase(jiraService);
+      sut
+        .execute(
+          new ReleaseVersionUseCaseInput(['fail', 'pass'], '1.0.0', undefined)
+        )
+        .subscribe({
+          next: () => {
+            fail();
+          },
+          error: () => {
+            verify(
+              jiraServiceMock.mock.releaseVersion(
+                anything(),
+                anything(),
+                anything()
+              )
+            ).twice();
+            done();
+          }
+        });
+    });
+  });
+});


### PR DESCRIPTION
This should make releasing across multiple projects much easier.

As a follow-up feature, we should first check for the [unresolved issue count](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-project-versions/#api-rest-api-3-version-id-unresolvedissuecount-get) such that we don't release a version when there are open tickets.