### PR TITLE
Updates lookup of milestones from newest first

### DIFF
--- a/src/services/github-service.ts
+++ b/src/services/github-service.ts
@@ -265,7 +265,8 @@ export class ConcreteGithubService implements GithubService {
     return from(
       this.octokit.issues.listMilestones({
         owner,
-        repo
+        repo,
+        direction: 'desc'
       })
     ).pipe(
       map((response) => {


### PR DESCRIPTION
When updating a release, we first fetch a list of milestones and look for a name.

But this lookup was returning older milestones first.

With this PR, we invert the lookup.

fixes #118 