### PR TITLE
Fix uncaught exception when tagging

### DIFF
--- a/src/endpoints/tag-endpoint.ts
+++ b/src/endpoints/tag-endpoint.ts
@@ -26,10 +26,16 @@ export interface TagEndpointInputMapper {
 export class TagEndpointResponse {
   successes: string[];
   failures: string[];
+  failuresOnProjectKeys: string[];
 
-  constructor(successes: string[], failures: string[]) {
+  constructor(
+    successes: string[],
+    failures: string[],
+    failuresOnProjectKeys: string[]
+  ) {
     this.successes = successes;
     this.failures = failures;
+    this.failuresOnProjectKeys = failuresOnProjectKeys;
   }
 }
 
@@ -55,6 +61,15 @@ export class TagEndpoint {
 
     return this.tagUseCase
       .execute(useCaseInput)
-      .pipe(map((x) => new TagEndpointResponse(x.successes, x.failures)));
+      .pipe(
+        map(
+          (x) =>
+            new TagEndpointResponse(
+              x.successes,
+              x.failures,
+              x.failuresOnProjectKeys
+            )
+        )
+      );
   }
 }

--- a/tests/endpoints/endpoints.test.ts
+++ b/tests/endpoints/endpoints.test.ts
@@ -107,7 +107,7 @@ describe('The tag endpoint', () => {
     const dependencies = new TestTagEndpointDependencies();
 
     when(dependencies.tagUseCaseMock.execute(anything())).thenReturn(
-      of(new TagUseCaseOutput([], []))
+      of(new TagUseCaseOutput([], [], []))
     );
 
     const sut = new TagEndpoint(dependencies);

--- a/tests/use-cases/create-release-use-case.test.ts
+++ b/tests/use-cases/create-release-use-case.test.ts
@@ -88,7 +88,7 @@ describe('the create release use case', () => {
           )
         )
       )
-    ).thenReturn(of(new TagUseCaseOutput([], [])));
+    ).thenReturn(of(new TagUseCaseOutput([], [], [])));
     when(
       createChangelogUseCaseMock.execute(
         deepEqual(

--- a/tests/use-cases/create-version-use-case.test.ts
+++ b/tests/use-cases/create-version-use-case.test.ts
@@ -4,7 +4,7 @@ import {
 } from '../../src/use-cases/create-version-use-case';
 import { mock, instance, when, anything, verify } from 'ts-mockito';
 import { JiraService } from '../../src/services/jira-service';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 describe('the create version use case', () => {
   it('does not call the service if version exists', (done) => {
@@ -51,6 +51,35 @@ describe('the create version use case', () => {
       .subscribe({
         next: () => {
           verify(jiraServiceMock.createVersion(anything(), anything())).twice();
+        },
+        complete: done
+      });
+  });
+
+  it('proceeds if one of the project keys errors', (done) => {
+    const jiraServiceMock = mock<JiraService>();
+
+    when(jiraServiceMock.hasVersion('1.1.0', 'FAI')).thenReturn(
+      throwError(Error('Error message'))
+    );
+    when(jiraServiceMock.hasVersion('1.1.0', 'PAS')).thenReturn(of(true));
+    when(jiraServiceMock.hasVersion('1.1.0', 'CRE')).thenReturn(of(false));
+    when(jiraServiceMock.projectIdFromKey(anything())).thenReturn(of(123));
+    when(jiraServiceMock.createVersion(anything(), anything())).thenReturn(
+      of(void 0)
+    );
+
+    const jiraService = instance(jiraServiceMock);
+    const sut = new JiraCreateVersionUseCase(jiraService);
+
+    sut
+      .execute(new CreateVersionUseCaseInput(['FAI', 'PAS', 'CRE'], '1.1.0'))
+      .subscribe({
+        next: (output) => {
+          expect(output[0].resultPerProjectKey.result).toBe('FAILED');
+          expect(output[1].resultPerProjectKey.result).toBe('EXISTED');
+          expect(output[2].resultPerProjectKey.result).toBe('CREATED');
+          verify(jiraServiceMock.createVersion(anything(), anything())).once();
         },
         complete: done
       });

--- a/tests/use-cases/tag-use-case.test.ts
+++ b/tests/use-cases/tag-use-case.test.ts
@@ -54,7 +54,9 @@ describe('The tag use case with PR', () => {
       of(new ConcreteJiraTicketTaggetOutput(['123'], []))
     );
     when(createVersionUseCaseMock.execute(anything())).thenReturn(
-      of(new CreateVersionUseCaseOutput())
+      of([
+        new CreateVersionUseCaseOutput({ projectKey: 'COM', result: 'CREATED' })
+      ])
     );
 
     const pullRequestCommitExtractor = instance(pullRequestCommitExtractorMock);
@@ -134,7 +136,12 @@ describe('The tag use case with SHA', () => {
       of(new ConcreteJiraTicketTaggetOutput(['123'], []))
     );
     when(createVersionUseCaseMock.execute(anything())).thenReturn(
-      of(new CreateVersionUseCaseOutput())
+      of([
+        new CreateVersionUseCaseOutput({
+          projectKey: 'COM',
+          result: 'CREATED'
+        })
+      ])
     );
 
     const pullRequestCommitExtractor = instance(pullRequestCommitExtractorMock);

--- a/tests/use-cases/update-release-use-case.test.ts
+++ b/tests/use-cases/update-release-use-case.test.ts
@@ -108,7 +108,8 @@ const happyCaseNoChangelogNoCommits = (): {
   when(mocks.tagUseCase.execute(anything())).thenReturn(
     of({
       successes: [],
-      failures: []
+      failures: [],
+      failuresOnProjectKeys: []
     })
   );
 
@@ -200,7 +201,8 @@ const jiraServiceFailing = (): {
   when(mocks.tagUseCase.execute(anything())).thenReturn(
     of({
       successes: [],
-      failures: []
+      failures: [],
+      failuresOnProjectKeys: []
     })
   );
 


### PR DESCRIPTION
When tagging, specifying a project key that did not exist resulted in an uncaught exception.

The root cause of the problem was the conversion of a promise to an observable using the `from` function.

With this PR, I update the use of the `from` and also allow the error to be sent on the JSON response of the tag endpoint.