### PR TITLE
Allow release with commits without PR’s

### DIFF
--- a/src/use-cases/create-changelog-use-case.ts
+++ b/src/use-cases/create-changelog-use-case.ts
@@ -1,4 +1,4 @@
-import { Observable, of } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { PullRequestNumberExtractor } from '../workers/pr-number-extractor';
 import { ReadPullRequestInfoUseCase } from './read-pull-request-info-use-case';
 import { flatMap, map } from 'rxjs/operators';
@@ -92,6 +92,9 @@ export class GithubCreateChangelogUseCase implements CreateChangelogUseCase {
     return this.pullRequestNumbers(input.origin, input.repository)
       .pipe(
         flatMap((numbers) => {
+          if (numbers.length === 0) {
+            return throwError(Error('No pull requests to build a changelog'));
+          }
           return this.pullRequestInfoUseCase.execute(numbers, input.repository);
         })
       )

--- a/src/use-cases/create-changelog-use-case.ts
+++ b/src/use-cases/create-changelog-use-case.ts
@@ -93,7 +93,9 @@ export class GithubCreateChangelogUseCase implements CreateChangelogUseCase {
       .pipe(
         flatMap((numbers) => {
           if (numbers.length === 0) {
-            return throwError(Error('No pull requests to build a changelog'));
+            return throwError(
+              new Error('No pull requests to build a changelog')
+            );
           }
           return this.pullRequestInfoUseCase.execute(numbers, input.repository);
         })

--- a/src/use-cases/create-milestone-use-case.ts
+++ b/src/use-cases/create-milestone-use-case.ts
@@ -1,4 +1,4 @@
-import { Observable, forkJoin } from 'rxjs';
+import { Observable, forkJoin, of } from 'rxjs';
 import { PullRequestNumberExtractor } from '../workers/pr-number-extractor';
 import { flatMap, mapTo } from 'rxjs/operators';
 import { MilestoneCreator } from '../workers/milestone-creator';
@@ -53,6 +53,9 @@ export class GithubCreateMilestoneUseCase implements CreateMilestoneUseCase {
             .create(input.title, input.repository)
             .pipe(
               flatMap((milestoneId) => {
+                if (numbers.length === 0) {
+                  return of(void 0);
+                }
                 const setMilestoneToPrs = numbers.map((prNumber) => {
                   return this.githubService.setMilestoneToPR(
                     this.owner,

--- a/src/use-cases/create-release-use-case.ts
+++ b/src/use-cases/create-release-use-case.ts
@@ -3,7 +3,7 @@ import {
   CreateBranchUseCase,
   CreateBranchUseCaseInput
 } from './create-branch-use-case';
-import { mapTo, flatMap } from 'rxjs/operators';
+import { mapTo, flatMap, catchError } from 'rxjs/operators';
 import { PullRequestCreator } from '../workers/pull-request-creator';
 import { TagUseCase, TagUseCaseInput } from './tag-use-case';
 import {
@@ -133,6 +133,11 @@ export class CreateReleaseUseCase {
                     input.repository,
                     input.projectTag
                   )
+                )
+                .pipe(
+                  catchError(() => {
+                    return of(undefined);
+                  })
                 )
                 .pipe(
                   flatMap((changelog) => {

--- a/src/workers/jira-tagger.ts
+++ b/src/workers/jira-tagger.ts
@@ -1,4 +1,4 @@
-import { Observable, of, from, forkJoin } from 'rxjs';
+import { Observable, of, from, forkJoin, defer } from 'rxjs';
 import JiraAPI from 'jira-client';
 import { catchError, map } from 'rxjs/operators';
 
@@ -44,7 +44,7 @@ export class ConcreteJiraTickerTagger implements JiraTicketTagger {
         }
       });
 
-      return from(updateIssuePromise)
+      return defer(() => from(updateIssuePromise))
         .pipe(
           map(() => {
             return { success: true, ticketId: ticketId };

--- a/tests/use-cases/create-changelog-use-case.test.ts
+++ b/tests/use-cases/create-changelog-use-case.test.ts
@@ -291,4 +291,64 @@ describe('the create changelog use case', () => {
         complete: done
       });
   });
+
+  it('when no pull request then throws error', (done) => {
+    const pullRequestNumberExtractorMock = mock<PullRequestNumberExtractor>();
+    const pullRequestInfoUseCaseMock = mock<ReadPullRequestInfoUseCase>();
+    const keepChangelogParserMock = mock<KeepChangelogParser>();
+    const keepChangelogBuilderMock = mock<KeepChangelogBuilder<string>>();
+    const blockKeepChangelogBuilderMock = mock<KeepChangelogBuilder<Block[]>>();
+    const commitPRNumberParserMock = mock<CommitPRNumberParser>();
+
+    when(pullRequestNumberExtractorMock.extract(123, 'repository')).thenReturn(
+      of([])
+    );
+
+    when(keepChangelogParserMock.parse('hello')).thenReturn(null);
+    when(
+      keepChangelogBuilderMock.build(
+        '1.0.0',
+        deepEqual([]),
+        deepEqual([]),
+        deepEqual([]),
+        deepEqual([]),
+        deepEqual([]),
+        deepEqual([])
+      )
+    ).thenReturn(undefined);
+
+    const pullRequestNumberExtractor = instance(pullRequestNumberExtractorMock);
+    const pullRequestInfoUseCase = instance(pullRequestInfoUseCaseMock);
+    const keepChangelogParser = instance(keepChangelogParserMock);
+    const keepChangelogBuilder = instance(keepChangelogBuilderMock);
+    const blockKeepChangelogBuilder = instance(blockKeepChangelogBuilderMock);
+    const commitPRNumberParser = instance(commitPRNumberParserMock);
+
+    const sut = new GithubCreateChangelogUseCase(
+      blockKeepChangelogBuilder,
+      commitPRNumberParser,
+      keepChangelogBuilder,
+      keepChangelogParser,
+      pullRequestInfoUseCase,
+      pullRequestNumberExtractor
+    );
+
+    sut
+      .execute(
+        new CreateChangelogInput(
+          { type: 'pullRequestNumber', number: 123 },
+          'repository',
+          '1.0.0'
+        )
+      )
+      .subscribe({
+        next: () => {
+          fail();
+        },
+        error: () => {
+          done();
+        },
+        complete: done
+      });
+  });
 });


### PR DESCRIPTION
When creating a release, if commits did not point to PRs, the endpoint would hang.
With this PR, we fix that.