### PR TITLE
Proceed releasing with a failure in use case

### DIFF
--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -41,7 +41,7 @@ import { ConcreteCommitPRNumberParser } from './workers/keep-changelog-builder/c
 import { ConcreteUpdateReleaseUseCase } from './use-cases/update-release-use-case';
 import { GithubDraftReleaseGuesser } from './workers/github-draft-release-guesser';
 import { ReleaseVersionEndpointDependencies } from './endpoints/release-version-endpoint';
-import { ReleaseVersionUseCase } from './use-cases/release-version-use-case';
+import { ConcreteReleaseVersionUseCase } from './use-cases/release-version-use-case';
 
 export class Dependencies
   implements
@@ -165,7 +165,7 @@ export class Dependencies
     this.createMilestoneUseCase
   );
 
-  releaseVersionUseCase = new ReleaseVersionUseCase(this.jiraService);
+  releaseVersionUseCase = new ConcreteReleaseVersionUseCase(this.jiraService);
 
   reactionsReader = new SlackReactionsReader(this.slackWebClient);
   nextReleaseGuesser = new GithubDraftReleaseGuesser(

--- a/src/endpoints/release-version-endpoint.ts
+++ b/src/endpoints/release-version-endpoint.ts
@@ -1,5 +1,5 @@
 import { ReleaseVersionUseCase } from '../use-cases/release-version-use-case';
-import { mapTo } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
 export interface ReleaseVersionEndpointInput {
@@ -9,7 +9,10 @@ export interface ReleaseVersionEndpointInput {
   readonly releaseDate?: string;
 }
 
-export class ReleaseVersionEndpointOutput {}
+export type ReleaseVersionEndpointOutput = {
+  failures: string[];
+  successes: string[];
+};
 
 export interface ReleaseVersionEndpointDependencies {
   releaseVersionUseCase: ReleaseVersionUseCase;
@@ -31,6 +34,16 @@ export class ReleaseVersionEndpoint {
         version: `${input.tag}${input.jiraTagSuffix}`,
         releaseDate: input.releaseDate
       })
-      .pipe(mapTo(new ReleaseVersionEndpointOutput()));
+      .pipe(
+        map((x) => {
+          const failures = x.result
+            .filter((x) => x.result === 'FAILED')
+            .map((x) => x.projectKey);
+          const successes = x.result
+            .filter((x) => x.result === 'RELEASED')
+            .map((x) => x.projectKey);
+          return { failures, successes };
+        })
+      );
   }
 }

--- a/src/services/jira-service.ts
+++ b/src/services/jira-service.ts
@@ -119,7 +119,7 @@ export class ConcreteJiraService implements JiraService {
 
           if (!match) {
             return throwError({
-              message: `Unable to find JIRA release named ${name}`
+              message: `Unable to find JIRA release named ${name} for projectKey ${projectKey}`
             });
           }
           return of(match);

--- a/src/use-cases/create-version-use-case.ts
+++ b/src/use-cases/create-version-use-case.ts
@@ -19,7 +19,7 @@ export class CreateVersionUseCaseInput {
   }
 }
 
-export type ResultPerProjectKey = {
+type ResultPerProjectKey = {
   readonly projectKey: string;
   readonly result: 'CREATED' | 'EXISTED' | 'FAILED';
 };

--- a/src/use-cases/release-version-use-case.ts
+++ b/src/use-cases/release-version-use-case.ts
@@ -2,13 +2,11 @@ import { forkJoin, Observable, of } from 'rxjs';
 import { catchError, map, mapTo } from 'rxjs/operators';
 import { JiraService } from '../services/jira-service';
 
-export class ReleaseVersionUseCaseInput {
-  constructor(
-    readonly projectKeys: string[],
-    readonly version: string,
-    readonly releaseDate?: string
-  ) {}
-}
+export type ReleaseVersionUseCaseInput = {
+  readonly projectKeys: string[];
+  readonly version: string;
+  readonly releaseDate?: string;
+};
 
 export class ReleaseVersionUseCaseOutput {
   readonly result: ResultPerProjectKey[];
@@ -22,7 +20,13 @@ type ResultPerProjectKey = {
   readonly result: 'RELEASED' | 'FAILED';
 };
 
-export class ReleaseVersionUseCase {
+export interface ReleaseVersionUseCase {
+  execute(
+    input: ReleaseVersionUseCaseInput
+  ): Observable<ReleaseVersionUseCaseOutput>;
+}
+
+export class ConcreteReleaseVersionUseCase {
   constructor(readonly jiraService: JiraService) {}
 
   execute(

--- a/src/use-cases/release-version-use-case.ts
+++ b/src/use-cases/release-version-use-case.ts
@@ -1,5 +1,5 @@
-import { forkJoin, Observable } from 'rxjs';
-import { mapTo } from 'rxjs/operators';
+import { forkJoin, Observable, of } from 'rxjs';
+import { catchError, map, mapTo } from 'rxjs/operators';
 import { JiraService } from '../services/jira-service';
 
 export class ReleaseVersionUseCaseInput {
@@ -10,27 +10,44 @@ export class ReleaseVersionUseCaseInput {
   ) {}
 }
 
-export class ReleaseVersionUseCaseOutput {}
+export class ReleaseVersionUseCaseOutput {
+  readonly result: ResultPerProjectKey[];
+  constructor(result: ResultPerProjectKey[]) {
+    this.result = result;
+  }
+}
+
+type ResultPerProjectKey = {
+  readonly projectKey: string;
+  readonly result: 'RELEASED' | 'FAILED';
+};
 
 export class ReleaseVersionUseCase {
   constructor(readonly jiraService: JiraService) {}
 
   execute(
     input: ReleaseVersionUseCaseInput
-  ): Observable<ReleaseVersionUseCaseOutput[]> {
+  ): Observable<ReleaseVersionUseCaseOutput> {
     const releaseVersions = input.projectKeys.map((projectKey) => {
       return this.releaseVersion(projectKey, input.version, input.releaseDate);
     });
-    return forkJoin(releaseVersions);
+    return forkJoin(releaseVersions).pipe(
+      map((x) => new ReleaseVersionUseCaseOutput(x))
+    );
   }
 
   private releaseVersion(
     projectKey: string,
     version: string,
     releaseDate?: string
-  ): Observable<ReleaseVersionUseCaseOutput> {
+  ): Observable<ResultPerProjectKey> {
     return this.jiraService
       .releaseVersion(version, projectKey, releaseDate)
-      .pipe(mapTo(new ReleaseVersionUseCaseOutput()));
+      .pipe(mapTo({ projectKey, result: 'RELEASED' } as ResultPerProjectKey))
+      .pipe(
+        catchError(() =>
+          of<ResultPerProjectKey>({ projectKey, result: 'FAILED' })
+        )
+      );
   }
 }

--- a/tests/mocks/mocks.ts
+++ b/tests/mocks/mocks.ts
@@ -1,6 +1,7 @@
 import { GithubServiceMock } from './github-service-mock';
 import { JiraServiceMock } from './jira-service-mock';
 import { PullRequestCreatorMock } from './pull-request-creator-mock';
+import { ReleaseVersionUseCaseMock } from './release-version-use-case-mock';
 
 export class Mocks {
   static githubService(owner: string, repo: string): GithubServiceMock {
@@ -13,5 +14,9 @@ export class Mocks {
 
   static jiraService(): JiraServiceMock {
     return new JiraServiceMock();
+  }
+
+  static releaseVersionUseCase(): ReleaseVersionUseCaseMock {
+    return new ReleaseVersionUseCaseMock();
   }
 }

--- a/tests/mocks/release-version-use-case-mock.ts
+++ b/tests/mocks/release-version-use-case-mock.ts
@@ -1,0 +1,34 @@
+import { of, throwError } from 'rxjs';
+import { deepEqual, instance, mock, when } from 'ts-mockito';
+import {
+  ReleaseVersionUseCase,
+  ReleaseVersionUseCaseInput,
+  ReleaseVersionUseCaseOutput
+} from '../../src/use-cases/release-version-use-case';
+
+export class ReleaseVersionUseCaseMock {
+  mock: ReleaseVersionUseCase;
+
+  constructor() {
+    this.mock = mock<ReleaseVersionUseCase>();
+  }
+
+  withError(input: ReleaseVersionUseCaseInput): ReleaseVersionUseCaseMock {
+    when(this.mock.execute(deepEqual(input))).thenReturn(
+      throwError(new Error('this is an error'))
+    );
+    return this;
+  }
+
+  withInputOutput(arg: {
+    input: ReleaseVersionUseCaseInput;
+    output: ReleaseVersionUseCaseOutput;
+  }): ReleaseVersionUseCaseMock {
+    when(this.mock.execute(deepEqual(arg.input))).thenReturn(of(arg.output));
+    return this;
+  }
+
+  build(): ReleaseVersionUseCase {
+    return instance(this.mock);
+  }
+}

--- a/tests/use-cases/release-version-use-case.test.ts
+++ b/tests/use-cases/release-version-use-case.test.ts
@@ -1,9 +1,6 @@
 import { anything, verify } from 'ts-mockito';
 import { JiraService } from '../../src/services/jira-service';
-import {
-  ConcreteReleaseVersionUseCase,
-  ReleaseVersionUseCaseInput
-} from '../../src/use-cases/release-version-use-case';
+import { ConcreteReleaseVersionUseCase } from '../../src/use-cases/release-version-use-case';
 import { JiraServiceMock } from '../mocks/jira-service-mock';
 import { Mocks } from '../mocks/mocks';
 
@@ -30,7 +27,11 @@ describe('the release version use case', () => {
     it('does not fail the use case', (done) => {
       const sut = new ConcreteReleaseVersionUseCase(jiraService);
       sut
-        .execute(new ReleaseVersionUseCaseInput(['pass'], '1.0.0', undefined))
+        .execute({
+          projectKeys: ['pass'],
+          version: '1.0.0',
+          releaseDate: undefined
+        })
         .subscribe({
           next: () => {
             done();
@@ -57,13 +58,11 @@ describe('the release version use case', () => {
     it('does not fail the use case', (done) => {
       const sut = new ConcreteReleaseVersionUseCase(jiraService);
       sut
-        .execute(
-          new ReleaseVersionUseCaseInput(
-            ['projectKey'],
-            'version',
-            'releaseDate'
-          )
-        )
+        .execute({
+          projectKeys: ['projectKey'],
+          version: 'version',
+          releaseDate: 'releaseDate'
+        })
         .subscribe({
           next: (x) => {
             expect(x.result[0].projectKey).toBe('projectKey');
@@ -97,9 +96,11 @@ describe('the release version use case', () => {
     it('does not fail the use case', (done) => {
       const sut = new ConcreteReleaseVersionUseCase(jiraService);
       sut
-        .execute(
-          new ReleaseVersionUseCaseInput(['fail', 'pass'], '1.0.0', undefined)
-        )
+        .execute({
+          projectKeys: ['fail', 'pass'],
+          version: '1.0.0',
+          releaseDate: undefined
+        })
         .subscribe({
           next: (x) => {
             expect(x.result[0].projectKey).toBe('fail');

--- a/tests/use-cases/release-version-use-case.test.ts
+++ b/tests/use-cases/release-version-use-case.test.ts
@@ -54,7 +54,7 @@ describe('the release version use case', () => {
         .build();
     });
 
-    it('fails the use case', (done) => {
+    it('does not fail the use case', (done) => {
       const sut = new ReleaseVersionUseCase(jiraService);
       sut
         .execute(
@@ -65,11 +65,13 @@ describe('the release version use case', () => {
           )
         )
         .subscribe({
-          next: () => {
-            fail();
+          next: (x) => {
+            expect(x.result[0].projectKey).toBe('projectKey');
+            expect(x.result[0].result).toBe('FAILED');
+            done();
           },
           error: () => {
-            done();
+            fail();
           }
         });
     });
@@ -92,17 +94,19 @@ describe('the release version use case', () => {
         .build();
     });
 
-    it('fails the use case', (done) => {
+    it('does not fail the use case', (done) => {
       const sut = new ReleaseVersionUseCase(jiraService);
       sut
         .execute(
           new ReleaseVersionUseCaseInput(['fail', 'pass'], '1.0.0', undefined)
         )
         .subscribe({
-          next: () => {
-            fail();
-          },
-          error: () => {
+          next: (x) => {
+            expect(x.result[0].projectKey).toBe('fail');
+            expect(x.result[0].result).toBe('FAILED');
+            expect(x.result[1].projectKey).toBe('pass');
+            expect(x.result[1].result).toBe('RELEASED');
+
             verify(
               jiraServiceMock.mock.releaseVersion(
                 anything(),
@@ -111,6 +115,9 @@ describe('the release version use case', () => {
               )
             ).twice();
             done();
+          },
+          error: () => {
+            fail();
           }
         });
     });

--- a/tests/use-cases/release-version-use-case.test.ts
+++ b/tests/use-cases/release-version-use-case.test.ts
@@ -1,7 +1,7 @@
 import { anything, verify } from 'ts-mockito';
 import { JiraService } from '../../src/services/jira-service';
 import {
-  ReleaseVersionUseCase,
+  ConcreteReleaseVersionUseCase,
   ReleaseVersionUseCaseInput
 } from '../../src/use-cases/release-version-use-case';
 import { JiraServiceMock } from '../mocks/jira-service-mock';
@@ -28,7 +28,7 @@ describe('the release version use case', () => {
     });
 
     it('does not fail the use case', (done) => {
-      const sut = new ReleaseVersionUseCase(jiraService);
+      const sut = new ConcreteReleaseVersionUseCase(jiraService);
       sut
         .execute(new ReleaseVersionUseCaseInput(['pass'], '1.0.0', undefined))
         .subscribe({
@@ -55,7 +55,7 @@ describe('the release version use case', () => {
     });
 
     it('does not fail the use case', (done) => {
-      const sut = new ReleaseVersionUseCase(jiraService);
+      const sut = new ConcreteReleaseVersionUseCase(jiraService);
       sut
         .execute(
           new ReleaseVersionUseCaseInput(
@@ -95,7 +95,7 @@ describe('the release version use case', () => {
     });
 
     it('does not fail the use case', (done) => {
-      const sut = new ReleaseVersionUseCase(jiraService);
+      const sut = new ConcreteReleaseVersionUseCase(jiraService);
       sut
         .execute(
           new ReleaseVersionUseCaseInput(['fail', 'pass'], '1.0.0', undefined)


### PR DESCRIPTION
When releasing in multiple projects, if one request failed (for example, release not found) then baroneza would not call release on the other project keys by design.

With this PR, we ignore errors and continue releasing for all project keys.

Reference: https://www.learnrxjs.io/learn-rxjs/operators/combination/forkjoin