### PR TITLE
Support creating Jira versions with descriptions

### DIFF
--- a/src/endpoints/create-release-endpoint.ts
+++ b/src/endpoints/create-release-endpoint.ts
@@ -12,6 +12,7 @@ export interface CreateReleaseEndpointInput {
   readonly repository: string;
   readonly channel: string;
   readonly jiraTagSuffix: string;
+  readonly jiraTagDescription?: string;
 }
 
 export class CreateReleaseEndpointOutput {}
@@ -40,7 +41,8 @@ export class CreateReleaseEndpoint {
         projectKeys: input.projectKeys,
         repository: input.repository,
         channel: input.channel,
-        jiraTagSuffix: input.jiraTagSuffix
+        jiraTagSuffix: input.jiraTagSuffix,
+        jiraTagDescription: input.jiraTagDescription
       })
       .pipe(mapTo(new CreateReleaseEndpointOutput()));
   }

--- a/src/services/jira-service.ts
+++ b/src/services/jira-service.ts
@@ -3,7 +3,11 @@ import JiraAPI from 'jira-client';
 import { flatMap, map, mapTo } from 'rxjs/operators';
 
 export interface JiraService {
-  createVersion(name: string, projectId: number): Observable<void>;
+  createVersion(
+    name: string,
+    projectId: number,
+    description?: string
+  ): Observable<void>;
   projectIdFromKey(projectKey: string): Observable<number>;
   hasVersion(name: string, projectKey: string): Observable<boolean>;
   hasFixVersion(issueNumber: string): Observable<boolean>;
@@ -26,11 +30,16 @@ export class ConcreteJiraService implements JiraService {
     this.jiraAPI = jiraAPI;
   }
 
-  createVersion(name: string, projectId: number): Observable<void> {
+  createVersion(
+    name: string,
+    projectId: number,
+    description?: string
+  ): Observable<void> {
     return defer(() =>
       from(
         this.jiraAPI.createVersion({
           projectId: projectId,
+          description,
           name
         })
       ).pipe(mapTo(void 0))

--- a/src/typings/jira-client/index.d.ts
+++ b/src/typings/jira-client/index.d.ts
@@ -431,6 +431,7 @@ declare module 'jira-client' {
     interface CreateVersionOptions {
       name: string;
       projectId: number;
+      description?: string;
     }
     interface UpdateVersionOptions {
       id: string;

--- a/src/use-cases/create-release-use-case.ts
+++ b/src/use-cases/create-release-use-case.ts
@@ -28,6 +28,7 @@ export class CreateReleaseUseCaseInput {
   repository: string;
   channel: string;
   jiraTagSuffix: string;
+  jiraTagDescription?: string;
 
   constructor(
     branchName: string,
@@ -38,7 +39,8 @@ export class CreateReleaseUseCaseInput {
     projectKeys: string[],
     repository: string,
     channel: string,
-    jiraTagSuffix: string
+    jiraTagSuffix: string,
+    jiraTagDescription?: string
   ) {
     this.branchName = branchName;
     this.referenceBranch = referenceBranch;
@@ -49,6 +51,7 @@ export class CreateReleaseUseCaseInput {
     this.repository = repository;
     this.channel = channel;
     this.jiraTagSuffix = jiraTagSuffix;
+    this.jiraTagDescription = jiraTagDescription;
   }
 }
 
@@ -121,7 +124,8 @@ export class CreateReleaseUseCase {
                 input.projectTag,
                 input.projectKeys,
                 input.repository,
-                input.jiraTagSuffix
+                input.jiraTagSuffix,
+                input.jiraTagDescription
               )
             )
           ).pipe(

--- a/src/use-cases/create-version-use-case.ts
+++ b/src/use-cases/create-version-use-case.ts
@@ -12,10 +12,12 @@ export interface CreateVersionUseCase {
 export class CreateVersionUseCaseInput {
   readonly projectKeys: string[];
   readonly version: string;
+  readonly description?: string;
 
-  constructor(projectKeys: string[], version: string) {
+  constructor(projectKeys: string[], version: string, description?: string) {
     this.projectKeys = projectKeys;
     this.version = version;
+    this.description = description;
   }
 }
 
@@ -43,14 +45,15 @@ export class JiraCreateVersionUseCase implements CreateVersionUseCase {
     input: CreateVersionUseCaseInput
   ): Observable<CreateVersionUseCaseOutput[]> {
     const createdVersions = input.projectKeys.map((projectKey) => {
-      return this.createVersion(projectKey, input.version);
+      return this.createVersion(projectKey, input.version, input.description);
     });
     return forkJoin(createdVersions);
   }
 
   private createVersion(
     projectKey: string,
-    version: string
+    version: string,
+    description?: string
   ): Observable<CreateVersionUseCaseOutput> {
     const createVersion = this.jiraService
       .projectIdFromKey(projectKey)

--- a/src/use-cases/create-version-use-case.ts
+++ b/src/use-cases/create-version-use-case.ts
@@ -59,7 +59,7 @@ export class JiraCreateVersionUseCase implements CreateVersionUseCase {
       .projectIdFromKey(projectKey)
       .pipe(
         flatMap((projectId) =>
-          this.jiraService.createVersion(version, projectId)
+          this.jiraService.createVersion(version, projectId, description)
         )
       )
       .pipe(

--- a/src/use-cases/tag-use-case.ts
+++ b/src/use-cases/tag-use-case.ts
@@ -18,19 +18,22 @@ export class TagUseCaseInput {
   readonly projectKeys: string[];
   readonly repository: string;
   readonly jiraTagSuffix: string;
+  readonly jiraTagDescription?: string;
 
   constructor(
     identifier: number | ShaWindow,
     tag: string,
     projectKeys: string[],
     repository: string,
-    jiraTagSuffix: string
+    jiraTagSuffix: string,
+    jiraTagDescription?: string
   ) {
     this.identifier = identifier;
     this.tag = tag;
     this.projectKeys = projectKeys;
     this.repository = repository;
     this.jiraTagSuffix = jiraTagSuffix;
+    this.jiraTagDescription = jiraTagDescription;
   }
 }
 
@@ -74,7 +77,13 @@ export class JiraTagUseCase implements TagUseCase {
         flatMap((extractTicketsOutput) => {
           const tag = `${input.tag}${input.jiraTagSuffix}`;
           return this.createVersionUseCase
-            .execute(new CreateVersionUseCaseInput(input.projectKeys, tag))
+            .execute(
+              new CreateVersionUseCaseInput(
+                input.projectKeys,
+                tag,
+                input.jiraTagDescription
+              )
+            )
             .pipe(
               flatMap((createVersionUseCaseOutput) =>
                 this.jiraTicketTagger

--- a/swagger.json
+++ b/swagger.json
@@ -155,6 +155,11 @@
                     "type": "string",
                     "example": "-backend",
                     "description": "This field will be concatenated as a suffix of the guessed next release"
+                  },
+                  "jiraTagDescription": {
+                    "type": "string",
+                    "example": "A hotfix release",
+                    "description": "This field will be used as the description of the Jira version"
                   }
                 }
               }

--- a/tests/use-cases/create-version-use-case.test.ts
+++ b/tests/use-cases/create-version-use-case.test.ts
@@ -37,20 +37,26 @@ describe('the create version use case', () => {
       of(false)
     );
     when(jiraServiceMock.projectIdFromKey(anything())).thenReturn(of(123));
-    when(jiraServiceMock.createVersion(anything(), anything())).thenReturn(
-      of(void 0)
-    );
+    when(
+      jiraServiceMock.createVersion(anything(), anything(), anything())
+    ).thenReturn(of(void 0));
 
     const jiraService = instance(jiraServiceMock);
     const sut = new JiraCreateVersionUseCase(jiraService);
 
     sut
       .execute(
-        new CreateVersionUseCaseInput(['project', 'otherProject'], 'version')
+        new CreateVersionUseCaseInput(
+          ['project', 'otherProject'],
+          'version',
+          'description'
+        )
       )
       .subscribe({
         next: () => {
-          verify(jiraServiceMock.createVersion(anything(), anything())).twice();
+          verify(
+            jiraServiceMock.createVersion(anything(), anything(), 'description')
+          ).twice();
         },
         complete: done
       });
@@ -65,9 +71,9 @@ describe('the create version use case', () => {
     when(jiraServiceMock.hasVersion('1.1.0', 'PAS')).thenReturn(of(true));
     when(jiraServiceMock.hasVersion('1.1.0', 'CRE')).thenReturn(of(false));
     when(jiraServiceMock.projectIdFromKey(anything())).thenReturn(of(123));
-    when(jiraServiceMock.createVersion(anything(), anything())).thenReturn(
-      of(void 0)
-    );
+    when(
+      jiraServiceMock.createVersion(anything(), anything(), anything())
+    ).thenReturn(of(void 0));
 
     const jiraService = instance(jiraServiceMock);
     const sut = new JiraCreateVersionUseCase(jiraService);
@@ -79,7 +85,9 @@ describe('the create version use case', () => {
           expect(output[0].resultPerProjectKey.result).toBe('FAILED');
           expect(output[1].resultPerProjectKey.result).toBe('EXISTED');
           expect(output[2].resultPerProjectKey.result).toBe('CREATED');
-          verify(jiraServiceMock.createVersion(anything(), anything())).once();
+          verify(
+            jiraServiceMock.createVersion(anything(), anything(), anything())
+          ).once();
         },
         complete: done
       });


### PR DESCRIPTION
By adding support for Jira version descriptions, we can link Fusion to native versions.
I wasn't sure about the naming, please let me know if you can come up with something better than `jiraTagDescription`.