### PR TITLE
Increases page size when fetching commits

### DIFF
--- a/src/services/github-service.ts
+++ b/src/services/github-service.ts
@@ -453,7 +453,9 @@ export class ConcreteGithubService implements GithubService {
         owner,
         repo,
         since: timeWindow.since,
-        until: timeWindow.until
+        until: timeWindow.until,
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        per_page: 100
       })
     ).pipe(
       map((response) => response.data),
@@ -471,7 +473,9 @@ export class ConcreteGithubService implements GithubService {
         owner,
         repo,
         // eslint-disable-next-line @typescript-eslint/camelcase
-        pull_number: pullNumber
+        pull_number: pullNumber,
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        per_page: 100
       })
     ).pipe(
       map((response) => response.data),


### PR DESCRIPTION
When fetching commits, from an interval, not specifying page size will result in only 30 results 😮‍💨 

Ideally we keep fetching if there are more results in the page, but for now I will increase the page to the limit Github allows