### PR TITLE
Fix ShaWindow validation and add Jira error logging

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { log, logError } from './logger';
 import { TagEndpoint } from './endpoints/tag-endpoint';
 import { Dependencies } from './dependencies';
 import bodyParser from 'body-parser';
@@ -17,10 +18,14 @@ const port = 3000;
 const dependencies = new Dependencies();
 
 app.post('/tagRelease', (req, res) => {
+  log(`[tagRelease] request received: ${JSON.stringify(req.body)}`);
   new TagEndpoint(dependencies).execute(req.body).subscribe(
-    (x) => res.send(x),
+    (x) => {
+      log(`[tagRelease] completed: ${JSON.stringify(x)}`);
+      res.send(x);
+    },
     (error) => {
-      console.log(error);
+      logError('[tagRelease] request failed', error);
       res.send(error);
     }
   );

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,7 @@
+const ts = () => new Date().toISOString();
+
+export const log = (msg: string) => console.log(`[${ts()}] ${msg}`);
+export const logError = (msg: string, err?: unknown) => {
+  const detail = err instanceof Error ? err.message : err;
+  console.error(`[${ts()}] ${msg}`, detail ?? '');
+};

--- a/src/services/github-service.ts
+++ b/src/services/github-service.ts
@@ -496,7 +496,7 @@ export class ConcreteGithubService implements GithubService {
       })
     ).pipe(
       map((response) => response.data),
-      map((data) => data.commit.author.date),
+      map((data) => (data.commit.author ?? data.commit.committer).date),
       map((date) => ({ date }))
     );
   }

--- a/src/use-cases/create-version-use-case.ts
+++ b/src/use-cases/create-version-use-case.ts
@@ -68,11 +68,13 @@ export class JiraCreateVersionUseCase implements CreateVersionUseCase {
 
     return this.jiraService.hasVersion(version, projectKey).pipe(
       catchError((err) => {
+        console.error(`[Jira] hasVersion failed for projectKey=${projectKey} version="${version}":`, err?.message ?? err);
         return of(err);
       }),
 
       flatMap((x) => {
         if (x instanceof Error) {
+          console.error(`[Jira] createVersion FAILED for projectKey=${projectKey} version="${version}":`, x?.message ?? x);
           return of(
             new CreateVersionUseCaseOutput({
               projectKey: projectKey,

--- a/src/use-cases/create-version-use-case.ts
+++ b/src/use-cases/create-version-use-case.ts
@@ -2,6 +2,7 @@ import { Observable, of } from 'rxjs';
 import { JiraService } from '../services/jira-service';
 import { catchError, flatMap, mapTo } from 'rxjs/operators';
 import { forkJoin } from 'rxjs';
+import { log, logError } from '../logger';
 
 export interface CreateVersionUseCase {
   execute(
@@ -58,23 +59,25 @@ export class JiraCreateVersionUseCase implements CreateVersionUseCase {
     const createVersion = this.jiraService
       .projectIdFromKey(projectKey)
       .pipe(
-        flatMap((projectId) =>
-          this.jiraService.createVersion(version, projectId, description)
-        )
+        flatMap((projectId) => {
+          log(`[CreateVersion] creating version "${version}" for projectKey=${projectKey} (id=${projectId})`);
+          return this.jiraService.createVersion(version, projectId, description);
+        })
       )
       .pipe(
         mapTo(new CreateVersionUseCaseOutput({ projectKey, result: 'CREATED' }))
       );
 
+    log(`[CreateVersion] checking if version "${version}" exists for projectKey=${projectKey}`);
     return this.jiraService.hasVersion(version, projectKey).pipe(
       catchError((err) => {
-        console.error(`[Jira] hasVersion failed for projectKey=${projectKey} version="${version}":`, err?.message ?? err);
+        logError(`[CreateVersion] hasVersion failed for projectKey=${projectKey} version="${version}"`, err);
         return of(err);
       }),
 
       flatMap((x) => {
         if (x instanceof Error) {
-          console.error(`[Jira] createVersion FAILED for projectKey=${projectKey} version="${version}":`, x?.message ?? x);
+          logError(`[CreateVersion] FAILED for projectKey=${projectKey} version="${version}"`, x);
           return of(
             new CreateVersionUseCaseOutput({
               projectKey: projectKey,
@@ -85,6 +88,7 @@ export class JiraCreateVersionUseCase implements CreateVersionUseCase {
           return createVersion;
         }
 
+        log(`[CreateVersion] version "${version}" already exists for projectKey=${projectKey}`);
         return of(
           new CreateVersionUseCaseOutput({ projectKey, result: 'EXISTED' })
         );

--- a/src/use-cases/extract-tickets-use-case.ts
+++ b/src/use-cases/extract-tickets-use-case.ts
@@ -62,8 +62,20 @@ export class ConcreteExtractTicketsUseCase implements ExtractTicketsUseCase {
         input.reference,
         input.repository
       );
+    } else if (
+      input.reference != null &&
+      typeof input.reference === 'object' &&
+      typeof (input.reference as ShaWindow).start === 'string' &&
+      typeof (input.reference as ShaWindow).end === 'string'
+    ) {
+      return this.shaCommitExtractor.commits(
+        input.reference as ShaWindow,
+        input.repository
+      );
     } else {
-      return this.shaCommitExtractor.commits(input.reference, input.repository);
+      throw new Error(
+        `Invalid reference: expected a pull request number or a ShaWindow object with "start" and "end" SHA strings, got: ${JSON.stringify(input.reference)}`
+      );
     }
   }
 }

--- a/src/use-cases/extract-tickets-use-case.ts
+++ b/src/use-cases/extract-tickets-use-case.ts
@@ -1,5 +1,6 @@
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
+import { log } from '../logger';
 import {
   GithubPullRequestExtractor,
   GithubShaExtractor,
@@ -42,6 +43,7 @@ export class ConcreteExtractTicketsUseCase implements ExtractTicketsUseCase {
 
   execute(input: ExtractTicketsInput): Observable<ExtractTicketsOutput> {
     return this.extractCommits(input)
+      .pipe(tap((commits) => log(`[ExtractTickets] fetched ${commits.length} commits from repository "${input.repository}"`)))
       .pipe(map((commits) => this.jiraTickerParser.parse(commits)))
       .pipe(
         map((jiraTickerParsedOutput) =>
@@ -52,12 +54,14 @@ export class ConcreteExtractTicketsUseCase implements ExtractTicketsUseCase {
             })
           )
         ),
+        tap((ticketIdsCommits) => log(`[ExtractTickets] parsed ${ticketIdsCommits.length} Jira tickets: ${ticketIdsCommits.map((t) => t.ticketId).join(', ')}`)),
         map((ticketIdsCommits): ExtractTicketsOutput => ({ ticketIdsCommits }))
       );
   }
 
   private extractCommits(input: ExtractTicketsInput): Observable<string[]> {
     if (typeof input.reference === 'number') {
+      log(`[ExtractTickets] extracting commits from PR #${input.reference} in "${input.repository}"`);
       return this.pullRequestCommitExtractor.commits(
         input.reference,
         input.repository
@@ -68,10 +72,9 @@ export class ConcreteExtractTicketsUseCase implements ExtractTicketsUseCase {
       typeof (input.reference as ShaWindow).start === 'string' &&
       typeof (input.reference as ShaWindow).end === 'string'
     ) {
-      return this.shaCommitExtractor.commits(
-        input.reference as ShaWindow,
-        input.repository
-      );
+      const window = input.reference as ShaWindow;
+      log(`[ExtractTickets] extracting commits from SHA window ${window.start}..${window.end} in "${input.repository}"`);
+      return this.shaCommitExtractor.commits(window, input.repository);
     } else {
       throw new Error(
         `Invalid reference: expected a pull request number or a ShaWindow object with "start" and "end" SHA strings, got: ${JSON.stringify(input.reference)}`

--- a/src/use-cases/tag-use-case.ts
+++ b/src/use-cases/tag-use-case.ts
@@ -1,5 +1,6 @@
 import { Observable } from 'rxjs';
 import { map, flatMap } from 'rxjs/operators';
+import { log } from '../logger';
 import { ShaWindow } from '../workers/commit-extractor';
 import { JiraTicketTagger } from '../workers/jira-tagger';
 import {
@@ -68,6 +69,7 @@ export class JiraTagUseCase implements TagUseCase {
   }
 
   execute(input: TagUseCaseInput): Observable<TagUseCaseOutput> {
+    log(`[TagUseCase] starting for tag="${input.tag}${input.jiraTagSuffix}" repository="${input.repository}" projectKeys=${JSON.stringify(input.projectKeys)}`);
     return this.extractTicketsUseCase
       .execute({
         reference: input.identifier,
@@ -76,6 +78,7 @@ export class JiraTagUseCase implements TagUseCase {
       .pipe(
         flatMap((extractTicketsOutput) => {
           const tag = `${input.tag}${input.jiraTagSuffix}`;
+          log(`[TagUseCase] creating Jira version "${tag}" for ${input.projectKeys.length} project keys`);
           return this.createVersionUseCase
             .execute(
               new CreateVersionUseCaseInput(
@@ -106,16 +109,15 @@ export class JiraTagUseCase implements TagUseCase {
         })
       )
       .pipe(
-        map(
-          (output) =>
-            new TagUseCaseOutput(
-              output.jiraTicketTaggetOutput.successes,
-              output.jiraTicketTaggetOutput.failures,
-              output.createVersionUseCaseOutput
-                .filter((x) => x.resultPerProjectKey.result === 'FAILED')
-                .map((x) => x.resultPerProjectKey.projectKey)
-            )
-        )
+        map((output) => {
+          const successes = output.jiraTicketTaggetOutput.successes;
+          const failures = output.jiraTicketTaggetOutput.failures;
+          const failuresOnProjectKeys = output.createVersionUseCaseOutput
+            .filter((x) => x.resultPerProjectKey.result === 'FAILED')
+            .map((x) => x.resultPerProjectKey.projectKey);
+          log(`[TagUseCase] done — successes=${successes.length} failures=${failures.length} failedProjectKeys=${JSON.stringify(failuresOnProjectKeys)}`);
+          return new TagUseCaseOutput(successes, failures, failuresOnProjectKeys);
+        })
       );
   }
 }

--- a/src/workers/jira-tagger.ts
+++ b/src/workers/jira-tagger.ts
@@ -1,6 +1,7 @@
 import { Observable, of, from, forkJoin, defer } from 'rxjs';
 import JiraAPI from 'jira-client';
 import { catchError, map } from 'rxjs/operators';
+import { log, logError } from '../logger';
 
 export interface JiraTicketTaggetOutput {
   readonly successes: string[];
@@ -29,6 +30,7 @@ export class ConcreteJiraTickerTagger implements JiraTicketTagger {
   }
 
   tag(ticketIds: string[], tag: string): Observable<JiraTicketTaggetOutput> {
+    log(`[JiraTagger] tagging ${ticketIds.length} tickets with "${tag}"`);
     const streams = ticketIds.map((ticketId) => {
       const updateIssuePromise = this.jiraAPI.updateIssue(ticketId, {
         update: {
@@ -50,7 +52,10 @@ export class ConcreteJiraTickerTagger implements JiraTicketTagger {
             return { success: true, ticketId: ticketId };
           })
         )
-        .pipe(catchError(() => of({ success: false, ticketId: ticketId })));
+        .pipe(catchError((err) => {
+          logError(`[JiraTagger] failed to tag ticket ${ticketId} with "${tag}"`, err);
+          return of({ success: false, ticketId: ticketId });
+        }));
     });
 
     return forkJoin(streams)
@@ -58,6 +63,7 @@ export class ConcreteJiraTickerTagger implements JiraTicketTagger {
         map((x) => {
           const failures = x.filter((x) => !x.success).map((x) => x.ticketId);
           const successes = x.filter((x) => x.success).map((x) => x.ticketId);
+          log(`[JiraTagger] done — successes=${successes.length} failures=${failures.length}`);
           return { successes, failures };
         })
       )


### PR DESCRIPTION
## Summary
- Validate `reference` is a proper `ShaWindow` object before passing to `shaCommitExtractor`; throws a descriptive error instead of a cryptic `TypeError: Cannot read properties of undefined (reading 'start')`
- Fallback to `committer.date` when `commit.author` is `null` in `getCommit` (GitHub API returns null for bot commits)
- Add `console.error` logging in Jira version creation failure paths to surface the actual Jira error in pm2 logs

## Test plan
- [ ] Hit `/tagRelease` with a valid `ShaWindow` reference and verify commits are extracted
- [ ] Hit `/tagRelease` with a missing/invalid `reference` and verify a descriptive error is returned
- [ ] Check pm2 logs after a Jira failure to confirm the error message is now visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)