### PR TITLE
Add support for Atlassian service tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,17 @@ You will need `npm` and then you can do `npm run start:watch`.
 To run tests you can use `jest`.
 You will also need a `.env` file with the following environment variables:
 ```
-JIRA_AUTH_TOKEN=
-JIRA_USER_NAME=
 GITHUB_AUTH_TOKEN=
 SLACK_AUTH_TOKEN=
+
+# Regular token auth (default):
+JIRA_AUTH_TOKEN=
+JIRA_USER_NAME=
+
+# Service token auth (Atlassian Global Gateway):
+# JIRA_AUTH_TYPE=service
+# JIRA_AUTH_TOKEN=
+# JIRA_CLOUD_ID=
 ```
 On slack, the app must be able to read reactions and write messages.
 You can configure many options in the `config.json` file.

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -59,13 +59,22 @@ export class Dependencies
       auth: this.keychain.githubAuthToken
     });
 
-  jiraAPI = (): JiraAPI =>
-    new JiraAPI({
+  jiraAPI = (): JiraAPI => {
+    if (this.keychain.jiraAuthType === 'service') {
+      return new JiraAPI({
+        host: 'api.atlassian.com',
+        protocol: 'https',
+        bearer: this.keychain.jiraAuthToken,
+        base: `ex/jira/${this.keychain.jiraCloudId}`
+      });
+    }
+    return new JiraAPI({
       host: this.config.jiraHost,
       protocol: 'https',
       username: this.keychain.jiraUserName,
       password: this.keychain.jiraAuthToken
     });
+  };
 
   githubService = new ConcreteGithubService(this.octokit());
   jiraService = new ConcreteJiraService(this.jiraAPI());

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -6,6 +6,8 @@ export class Keychain {
   jiraAuthToken: string;
   jiraUserName: string;
   slackAuthToken: string;
+  jiraAuthType: string;
+  jiraCloudId: string | undefined;
 
   constructor(processEnv: NodeJS.ProcessEnv) {
     if (!isProd()) {
@@ -16,5 +18,7 @@ export class Keychain {
     this.jiraAuthToken = processEnv.JIRA_AUTH_TOKEN;
     this.slackAuthToken = processEnv.SLACK_AUTH_TOKEN;
     this.jiraUserName = processEnv.JIRA_USER_NAME;
+    this.jiraAuthType = processEnv.JIRA_AUTH_TYPE ?? 'regular';
+    this.jiraCloudId = processEnv.JIRA_CLOUD_ID;
   }
 }

--- a/src/process-env.ts
+++ b/src/process-env.ts
@@ -7,6 +7,8 @@ declare global {
       SLACK_AUTH_TOKEN: string;
       JIRA_USER_NAME: string;
       JIRA_HOST: string;
+      JIRA_AUTH_TYPE?: 'regular' | 'service';
+      JIRA_CLOUD_ID?: string;
     }
   }
 }

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -1,0 +1,41 @@
+import { Keychain } from '../src/keys';
+
+const baseEnv: NodeJS.ProcessEnv = {
+  NODE_ENV: 'test',
+  GITHUB_AUTH_TOKEN: 'github-token',
+  JIRA_AUTH_TOKEN: 'jira-token',
+  JIRA_USER_NAME: 'jira-user',
+  SLACK_AUTH_TOKEN: 'slack-token',
+  JIRA_HOST: 'example.atlassian.net'
+};
+
+describe('Keychain', () => {
+  describe('jiraAuthType', () => {
+    it('defaults to "regular" when JIRA_AUTH_TYPE is not set', () => {
+      const keychain = new Keychain({ ...baseEnv });
+      expect(keychain.jiraAuthType).toBe('regular');
+    });
+
+    it('is "regular" when JIRA_AUTH_TYPE is explicitly "regular"', () => {
+      const keychain = new Keychain({ ...baseEnv, JIRA_AUTH_TYPE: 'regular' });
+      expect(keychain.jiraAuthType).toBe('regular');
+    });
+
+    it('is "service" when JIRA_AUTH_TYPE is "service"', () => {
+      const keychain = new Keychain({ ...baseEnv, JIRA_AUTH_TYPE: 'service' });
+      expect(keychain.jiraAuthType).toBe('service');
+    });
+  });
+
+  describe('jiraCloudId', () => {
+    it('is undefined when JIRA_CLOUD_ID is not set', () => {
+      const keychain = new Keychain({ ...baseEnv });
+      expect(keychain.jiraCloudId).toBeUndefined();
+    });
+
+    it('is set when JIRA_CLOUD_ID is provided', () => {
+      const keychain = new Keychain({ ...baseEnv, JIRA_CLOUD_ID: 'abc123' });
+      expect(keychain.jiraCloudId).toBe('abc123');
+    });
+  });
+});


### PR DESCRIPTION
## Summary                                             

  - Atlassian service tokens require a different host (`api.atlassian.com/ex/jira/<CLOUD_ID>/...`) and Bearer auth, whereas regular API tokens use the instance URL with HTTP Basic auth. This adds support for both modes, configurable via environment variables.
  - `JIRA_AUTH_TYPE=service` switches to Bearer auth against the global gateway; omitting it (or setting `regular`) preserves the existing behaviour — no breaking change for current deployments.                                                                                                                                                             
  - `JIRA_CLOUD_ID` is a new optional env var holding the Atlassian cloud ID, only required in service token mode.
                                                                                                                                                                                   
  ## Changes                                             
                                                                                                                                                                                   
  - `src/process-env.ts` — declares `JIRA_AUTH_TYPE` and `JIRA_CLOUD_ID` as optional env vars                                                                                      
  - `src/keys.ts` — reads both new vars into `Keychain`; `jiraAuthType` defaults to `'regular'`
  - `src/dependencies.ts` — `jiraAPI()` factory branches on `jiraAuthType` to build the correct `JiraAPI` options                                                                  
  - `README.md` — documents both auth modes in the `.env` setup section                                                                                                            
  - `tests/keys.test.ts` — new tests covering the defaulting and reading logic for both new fields                                                                                 
                                                                                                                                                                                   
  ## Test plan                                                                                                                                                                     
                                                                                                                                                                                   
  - [ ] Set `JIRA_AUTH_TYPE=service`, `JIRA_CLOUD_ID=<id>`, `JIRA_AUTH_TOKEN=<service-token>` and verify requests go to `api.atlassian.com/ex/jira/<id>/...` with `Authorization: Bearer`
  - [ ] Leave `JIRA_AUTH_TYPE` unset and verify existing basic auth behaviour is unchanged                                                                                         
  - [ ] `npm test` — all 64 tests pass           