### PR TITLE
Add live service key check endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,12 +11,19 @@ import { UpdateReleaseEndpoint } from './endpoints/update-release-endpoint';
 import { ReleaseVersionEndpoint } from './endpoints/release-version-endpoint';
 import { GuessNextReleaseEndpoint } from './endpoints/guess-next-release-endpoint';
 import { ReleaseReadinessEndpoint } from './endpoints/release-readiness-endpoint';
+import { CheckKeysEndpoint } from './endpoints/check-keys-endpoint';
 
 const app = express();
 app.use(bodyParser.json());
 
 const port = 3000;
 const dependencies = new Dependencies();
+
+app.get('/checkKeys', (_req, res) => {
+  new CheckKeysEndpoint(dependencies).execute().subscribe((response) => {
+    res.status(response.ok ? 200 : 500).send(response);
+  });
+});
 
 app.post('/tagRelease', (req, res) => {
   log(`[tagRelease] request received: ${JSON.stringify(req.body)}`);

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -91,6 +91,7 @@ export class Dependencies
   githubService = new ConcreteGithubService(this.octokit());
   jiraService = new ConcreteJiraService(this.jiraAPI());
   slackWebClient = new WebClient(this.keychain.slackAuthToken);
+  slackAppWebClient = new WebClient(this.keychain.slackAppToken);
 
   pullRequestCommitExtractor = new GithubPullRequestExtractor(
     this.githubService,

--- a/src/endpoints/check-keys-endpoint.ts
+++ b/src/endpoints/check-keys-endpoint.ts
@@ -1,0 +1,204 @@
+import { Observable, from } from 'rxjs';
+import { Keychain } from '../keys';
+
+type GithubClient = {
+  users: {
+    getAuthenticated(): Promise<unknown>;
+  };
+};
+
+type JiraClient = {
+  getCurrentUser(): Promise<unknown>;
+};
+
+type SlackClient = {
+  auth: {
+    test(): Promise<{ ok?: boolean; error?: string }>;
+  };
+};
+
+export interface CheckKeysEndpointDependencies {
+  readonly keychain: Keychain;
+  octokit(): GithubClient;
+  jiraAPI(): JiraClient;
+  readonly slackWebClient: SlackClient;
+  readonly slackAppWebClient: SlackClient;
+}
+
+export type ServiceCheck = {
+  configured: boolean;
+  responding: boolean;
+  error?: string;
+};
+
+export type CheckKeysEndpointResponse = {
+  ok: boolean;
+  jiraAuthType: string;
+  services: {
+    github: ServiceCheck;
+    jira: ServiceCheck;
+    slackBot: ServiceCheck;
+    slackApp: ServiceCheck;
+  };
+};
+
+export class CheckKeysEndpoint {
+  private readonly dependencies: CheckKeysEndpointDependencies;
+
+  constructor(dependencies: CheckKeysEndpointDependencies) {
+    this.dependencies = dependencies;
+  }
+
+  execute(): Observable<CheckKeysEndpointResponse> {
+    return from(this.checkServices());
+  }
+
+  private async checkServices(): Promise<CheckKeysEndpointResponse> {
+    const [github, jira, slackBot, slackApp] = await Promise.all([
+      this.checkGithub(),
+      this.checkJira(),
+      this.checkSlackBot(),
+      this.checkSlackApp()
+    ]);
+
+    return {
+      ok:
+        github.responding &&
+        jira.responding &&
+        slackBot.responding &&
+        slackApp.responding,
+      jiraAuthType: this.dependencies.keychain.jiraAuthType,
+      services: {
+        github,
+        jira,
+        slackBot,
+        slackApp
+      }
+    };
+  }
+
+  private async checkGithub(): Promise<ServiceCheck> {
+    if (!this.isConfigured(this.dependencies.keychain.githubAuthToken)) {
+      return this.missing('GITHUB_AUTH_TOKEN');
+    }
+
+    return this.checkService(() =>
+      this.dependencies.octokit().users.getAuthenticated()
+    );
+  }
+
+  private async checkJira(): Promise<ServiceCheck> {
+    const missingKeys = this.missingJiraKeys();
+    if (missingKeys.length > 0) {
+      return this.missing(missingKeys.join(', '));
+    }
+
+    if (
+      this.dependencies.keychain.jiraAuthType !== 'regular' &&
+      this.dependencies.keychain.jiraAuthType !== 'service'
+    ) {
+      return {
+        configured: true,
+        responding: false,
+        error: 'JIRA_AUTH_TYPE must be either "regular" or "service".'
+      };
+    }
+
+    return this.checkService(() =>
+      this.dependencies.jiraAPI().getCurrentUser()
+    );
+  }
+
+  private async checkSlackBot(): Promise<ServiceCheck> {
+    if (!this.isConfigured(this.dependencies.keychain.slackAuthToken)) {
+      return this.missing('SLACK_AUTH_TOKEN');
+    }
+
+    return this.checkSlackAuth(() =>
+      this.dependencies.slackWebClient.auth.test()
+    );
+  }
+
+  private async checkSlackApp(): Promise<ServiceCheck> {
+    if (!this.isConfigured(this.dependencies.keychain.slackAppToken)) {
+      return this.missing('SLACK_APP_TOKEN');
+    }
+
+    return this.checkSlackAuth(() =>
+      this.dependencies.slackAppWebClient.auth.test()
+    );
+  }
+
+  private async checkService(
+    check: () => Promise<unknown>
+  ): Promise<ServiceCheck> {
+    try {
+      await check();
+      return {
+        configured: true,
+        responding: true
+      };
+    } catch (error) {
+      return {
+        configured: true,
+        responding: false,
+        error: this.errorMessage(error)
+      };
+    }
+  }
+
+  private async checkSlackAuth(
+    check: () => Promise<{ ok?: boolean; error?: string }>
+  ): Promise<ServiceCheck> {
+    return this.checkService(async () => {
+      const response = await check();
+      if (response.ok === false) {
+        throw new Error(response.error ?? 'Slack token rejected');
+      }
+    });
+  }
+
+  private missingJiraKeys(): string[] {
+    const missingKeys: string[] = [];
+
+    if (!this.isConfigured(this.dependencies.keychain.jiraAuthToken)) {
+      missingKeys.push('JIRA_AUTH_TOKEN');
+    }
+
+    if (
+      this.dependencies.keychain.jiraAuthType === 'service' &&
+      !this.isConfigured(this.dependencies.keychain.jiraCloudId)
+    ) {
+      missingKeys.push('JIRA_CLOUD_ID');
+    }
+
+    if (
+      this.dependencies.keychain.jiraAuthType !== 'service' &&
+      !this.isConfigured(this.dependencies.keychain.jiraUserName)
+    ) {
+      missingKeys.push('JIRA_USER_NAME');
+    }
+
+    return missingKeys;
+  }
+
+  private missing(key: string): ServiceCheck {
+    return {
+      configured: false,
+      responding: false,
+      error: `Missing ${key}`
+    };
+  }
+
+  private isConfigured(value: string | undefined): boolean {
+    return typeof value === 'string' && value.trim().length > 0;
+  }
+
+  private errorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return 'Unknown error';
+  }
+}

--- a/swagger.json
+++ b/swagger.json
@@ -16,8 +16,21 @@
     }
   ],
   "components": {},
-  "paths": {
-    "/startTrain": {
+    "paths": {
+        "/checkKeys": {
+            "get": {
+                "description": "Checks whether configured GitHub, Jira, Slack bot, and Slack app tokens can authenticate with their services. Token values are never returned.",
+                "responses": {
+                    "200": {
+                        "description": "All configured services responded successfully"
+                    },
+                    "500": {
+                        "description": "One or more services failed authentication or required keys are missing"
+                    }
+                }
+            }
+        },
+        "/startTrain": {
       "post": {
         "description": "This endpoint guesses the next release of the repository, creates a PR, reads the commits, parses the commit messages, tags the tickets and creates a changelog",
         "requestBody": {

--- a/tests/endpoints/check-keys-endpoint.test.ts
+++ b/tests/endpoints/check-keys-endpoint.test.ts
@@ -1,0 +1,150 @@
+import {
+  CheckKeysEndpoint,
+  CheckKeysEndpointDependencies
+} from '../../src/endpoints/check-keys-endpoint';
+import { Keychain } from '../../src/keys';
+
+const regularEnv: NodeJS.ProcessEnv = {
+  NODE_ENV: 'test',
+  GITHUB_AUTH_TOKEN: 'github-token',
+  JIRA_AUTH_TOKEN: 'jira-token',
+  JIRA_HOST: 'example.atlassian.net',
+  JIRA_USER_NAME: 'jira-user',
+  SLACK_AUTH_TOKEN: 'slack-token',
+  SLACK_APP_TOKEN: 'slack-app-token'
+};
+
+const dependencies = (
+  env: NodeJS.ProcessEnv,
+  overrides: Partial<CheckKeysEndpointDependencies> = {}
+): CheckKeysEndpointDependencies => ({
+  keychain: new Keychain(env),
+  octokit: (): ReturnType<CheckKeysEndpointDependencies['octokit']> => ({
+    users: {
+      getAuthenticated: jest.fn().mockResolvedValue({})
+    }
+  }),
+  jiraAPI: (): ReturnType<CheckKeysEndpointDependencies['jiraAPI']> => ({
+    getCurrentUser: jest.fn().mockResolvedValue({})
+  }),
+  slackWebClient: {
+    auth: {
+      test: jest.fn().mockResolvedValue({ ok: true })
+    }
+  },
+  slackAppWebClient: {
+    auth: {
+      test: jest.fn().mockResolvedValue({ ok: true })
+    }
+  },
+  ...overrides
+});
+
+const buildEndpoint = (
+  env: NodeJS.ProcessEnv,
+  overrides: Partial<CheckKeysEndpointDependencies> = {}
+): CheckKeysEndpoint => new CheckKeysEndpoint(dependencies(env, overrides));
+
+describe('The check keys endpoint', () => {
+  it('returns ok when all services respond', (done) => {
+    buildEndpoint(regularEnv)
+      .execute()
+      .subscribe((response) => {
+        expect(response.ok).toBe(true);
+        expect(response.services.github.responding).toBe(true);
+        expect(response.services.jira.responding).toBe(true);
+        expect(response.services.slackBot.responding).toBe(true);
+        expect(response.services.slackApp.responding).toBe(true);
+        done();
+      });
+  });
+
+  it('uses Jira cloud id for service auth', (done) => {
+    buildEndpoint({
+      ...regularEnv,
+      JIRA_AUTH_TYPE: 'service',
+      JIRA_USER_NAME: '',
+      JIRA_CLOUD_ID: 'cloud-id'
+    })
+      .execute()
+      .subscribe((response) => {
+        expect(response.ok).toBe(true);
+        expect(response.jiraAuthType).toBe('service');
+        expect(response.services.jira.responding).toBe(true);
+        done();
+      });
+  });
+
+  it('does not call services with missing required keys', (done) => {
+    const slackAppAuthTest = jest.fn().mockResolvedValue({ ok: true });
+
+    buildEndpoint(
+      {
+        ...regularEnv,
+        SLACK_APP_TOKEN: ''
+      },
+      {
+        slackAppWebClient: {
+          auth: {
+            test: slackAppAuthTest
+          }
+        }
+      }
+    )
+      .execute()
+      .subscribe((response) => {
+        expect(response.ok).toBe(false);
+        expect(response.services.slackApp).toEqual({
+          configured: false,
+          responding: false,
+          error: 'Missing SLACK_APP_TOKEN'
+        });
+        expect(slackAppAuthTest).not.toHaveBeenCalled();
+        done();
+      });
+  });
+
+  it('reports service failures', (done) => {
+    buildEndpoint(regularEnv, {
+      octokit: (): ReturnType<CheckKeysEndpointDependencies['octokit']> => ({
+        users: {
+          getAuthenticated: jest
+            .fn()
+            .mockRejectedValue(new Error('Bad credentials'))
+        }
+      })
+    })
+      .execute()
+      .subscribe((response) => {
+        expect(response.ok).toBe(false);
+        expect(response.services.github).toEqual({
+          configured: true,
+          responding: false,
+          error: 'Bad credentials'
+        });
+        done();
+      });
+  });
+
+  it('reports Slack token rejection responses', (done) => {
+    buildEndpoint(regularEnv, {
+      slackWebClient: {
+        auth: {
+          test: jest
+            .fn()
+            .mockResolvedValue({ ok: false, error: 'invalid_auth' })
+        }
+      }
+    })
+      .execute()
+      .subscribe((response) => {
+        expect(response.ok).toBe(false);
+        expect(response.services.slackBot).toEqual({
+          configured: true,
+          responding: false,
+          error: 'invalid_auth'
+        });
+        done();
+      });
+  });
+});

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -6,6 +6,7 @@ const baseEnv: NodeJS.ProcessEnv = {
   JIRA_AUTH_TOKEN: 'jira-token',
   JIRA_USER_NAME: 'jira-user',
   SLACK_AUTH_TOKEN: 'slack-token',
+  SLACK_APP_TOKEN: 'slack-app-token',
   JIRA_HOST: 'example.atlassian.net'
 };
 


### PR DESCRIPTION
Adds GET /checkKeys to verify configured GitHub, Jira, Slack bot, and Slack app credentials by calling each service without exposing token values. Wires a Slack app-level WebClient for the app token check and documents the endpoint in Swagger. Adds focused tests for successful checks, missing keys, Jira service auth, and service authentication failures.