### PR TITLE
Use project versions for Jira key check

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -19,10 +19,17 @@ app.use(bodyParser.json());
 const port = 3000;
 const dependencies = new Dependencies();
 
-app.get('/checkKeys', (_req, res) => {
-  new CheckKeysEndpoint(dependencies).execute().subscribe((response) => {
-    res.status(response.ok ? 200 : 500).send(response);
-  });
+app.get('/checkKeys', (req, res) => {
+  const jiraProjectKey =
+    typeof req.query.jiraProjectKey === 'string'
+      ? req.query.jiraProjectKey
+      : undefined;
+
+  new CheckKeysEndpoint(dependencies)
+    .execute({ jiraProjectKey })
+    .subscribe((response) => {
+      res.status(response.ok ? 200 : 500).send(response);
+    });
 });
 
 app.post('/tagRelease', (req, res) => {

--- a/src/endpoints/check-keys-endpoint.ts
+++ b/src/endpoints/check-keys-endpoint.ts
@@ -8,7 +8,7 @@ type GithubClient = {
 };
 
 type JiraClient = {
-  getCurrentUser(): Promise<unknown>;
+  getVersions(projectKey: string): Promise<unknown>;
 };
 
 type SlackClient = {
@@ -24,6 +24,10 @@ export interface CheckKeysEndpointDependencies {
   readonly slackWebClient: SlackClient;
   readonly slackAppWebClient: SlackClient;
 }
+
+export type CheckKeysEndpointInput = {
+  jiraProjectKey?: string;
+};
 
 export type ServiceCheck = {
   configured: boolean;
@@ -49,14 +53,18 @@ export class CheckKeysEndpoint {
     this.dependencies = dependencies;
   }
 
-  execute(): Observable<CheckKeysEndpointResponse> {
-    return from(this.checkServices());
+  execute(
+    input: CheckKeysEndpointInput = {}
+  ): Observable<CheckKeysEndpointResponse> {
+    return from(this.checkServices(input));
   }
 
-  private async checkServices(): Promise<CheckKeysEndpointResponse> {
+  private async checkServices(
+    input: CheckKeysEndpointInput
+  ): Promise<CheckKeysEndpointResponse> {
     const [github, jira, slackBot, slackApp] = await Promise.all([
       this.checkGithub(),
-      this.checkJira(),
+      this.checkJira(input),
       this.checkSlackBot(),
       this.checkSlackApp()
     ]);
@@ -87,7 +95,9 @@ export class CheckKeysEndpoint {
     );
   }
 
-  private async checkJira(): Promise<ServiceCheck> {
+  private async checkJira(
+    input: CheckKeysEndpointInput
+  ): Promise<ServiceCheck> {
     const missingKeys = this.missingJiraKeys();
     if (missingKeys.length > 0) {
       return this.missing(missingKeys.join(', '));
@@ -104,8 +114,12 @@ export class CheckKeysEndpoint {
       };
     }
 
+    if (!this.isConfigured(input.jiraProjectKey)) {
+      return this.missing('jiraProjectKey query parameter');
+    }
+
     return this.checkService(() =>
-      this.dependencies.jiraAPI().getCurrentUser()
+      this.dependencies.jiraAPI().getVersions(input.jiraProjectKey as string)
     );
   }
 

--- a/swagger.json
+++ b/swagger.json
@@ -20,6 +20,18 @@
         "/checkKeys": {
             "get": {
                 "description": "Checks whether configured GitHub, Jira, Slack bot, and Slack app tokens can authenticate with their services. Token values are never returned.",
+                "parameters": [
+                    {
+                        "name": "jiraProjectKey",
+                        "in": "query",
+                        "required": true,
+                        "description": "A Jira project key used to validate Jira access through the project versions API.",
+                        "schema": {
+                            "type": "string",
+                            "example": "ABC"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "All configured services responded successfully"

--- a/tests/endpoints/check-keys-endpoint.test.ts
+++ b/tests/endpoints/check-keys-endpoint.test.ts
@@ -25,7 +25,7 @@ const dependencies = (
     }
   }),
   jiraAPI: (): ReturnType<CheckKeysEndpointDependencies['jiraAPI']> => ({
-    getCurrentUser: jest.fn().mockResolvedValue({})
+    getVersions: jest.fn().mockResolvedValue([])
   }),
   slackWebClient: {
     auth: {
@@ -48,7 +48,7 @@ const buildEndpoint = (
 describe('The check keys endpoint', () => {
   it('returns ok when all services respond', (done) => {
     buildEndpoint(regularEnv)
-      .execute()
+      .execute({ jiraProjectKey: 'ABC' })
       .subscribe((response) => {
         expect(response.ok).toBe(true);
         expect(response.services.github.responding).toBe(true);
@@ -66,11 +66,32 @@ describe('The check keys endpoint', () => {
       JIRA_USER_NAME: '',
       JIRA_CLOUD_ID: 'cloud-id'
     })
-      .execute()
+      .execute({ jiraProjectKey: 'ABC' })
       .subscribe((response) => {
         expect(response.ok).toBe(true);
         expect(response.jiraAuthType).toBe('service');
         expect(response.services.jira.responding).toBe(true);
+        done();
+      });
+  });
+
+  it('requires a Jira project key for the Jira service check', (done) => {
+    const getVersions = jest.fn().mockResolvedValue([]);
+
+    buildEndpoint(regularEnv, {
+      jiraAPI: () => ({
+        getVersions
+      })
+    })
+      .execute()
+      .subscribe((response) => {
+        expect(response.ok).toBe(false);
+        expect(response.services.jira).toEqual({
+          configured: false,
+          responding: false,
+          error: 'Missing jiraProjectKey query parameter'
+        });
+        expect(getVersions).not.toHaveBeenCalled();
         done();
       });
   });
@@ -91,7 +112,7 @@ describe('The check keys endpoint', () => {
         }
       }
     )
-      .execute()
+      .execute({ jiraProjectKey: 'ABC' })
       .subscribe((response) => {
         expect(response.ok).toBe(false);
         expect(response.services.slackApp).toEqual({
@@ -114,7 +135,7 @@ describe('The check keys endpoint', () => {
         }
       })
     })
-      .execute()
+      .execute({ jiraProjectKey: 'ABC' })
       .subscribe((response) => {
         expect(response.ok).toBe(false);
         expect(response.services.github).toEqual({
@@ -136,7 +157,7 @@ describe('The check keys endpoint', () => {
         }
       }
     })
-      .execute()
+      .execute({ jiraProjectKey: 'ABC' })
       .subscribe((response) => {
         expect(response.ok).toBe(false);
         expect(response.services.slackBot).toEqual({


### PR DESCRIPTION
Changes GET /checkKeys to validate Jira by reading project versions with a jiraProjectKey query parameter instead of calling the user-profile /myself endpoint. This keeps the diagnostic endpoint aligned with service-token usage and avoids requiring read:jira-user just for the check. Updates Swagger and endpoint tests, including a regression test for missing jiraProjectKey. Verified with npm run build, npm test -- --runInBand, focused endpoint tests, and touched-file ESLint.