### PR TITLE
Add Slack ping and socket checks

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -24,9 +24,13 @@ app.get('/checkKeys', (req, res) => {
     typeof req.query.jiraProjectKey === 'string'
       ? req.query.jiraProjectKey
       : undefined;
+  const slackChannel =
+    typeof req.query.slackChannel === 'string'
+      ? req.query.slackChannel
+      : undefined;
 
   new CheckKeysEndpoint(dependencies)
-    .execute({ jiraProjectKey })
+    .execute({ jiraProjectKey, slackChannel })
     .subscribe((response) => {
       res.status(response.ok ? 200 : 500).send(response);
     });

--- a/src/endpoints/check-keys-endpoint.ts
+++ b/src/endpoints/check-keys-endpoint.ts
@@ -17,16 +17,34 @@ type SlackClient = {
   };
 };
 
+type SlackAppClient = SlackClient & {
+  apps: {
+    connections: {
+      open(): Promise<{ ok?: boolean; error?: string; url?: string }>;
+    };
+  };
+};
+
+type SlackBotClient = SlackClient & {
+  chat: {
+    postMessage(message: {
+      channel: string;
+      text: string;
+    }): Promise<{ ok?: boolean; error?: string }>;
+  };
+};
+
 export interface CheckKeysEndpointDependencies {
   readonly keychain: Keychain;
   octokit(): GithubClient;
   jiraAPI(): JiraClient;
-  readonly slackWebClient: SlackClient;
-  readonly slackAppWebClient: SlackClient;
+  readonly slackWebClient: SlackBotClient;
+  readonly slackAppWebClient: SlackAppClient;
 }
 
 export type CheckKeysEndpointInput = {
   jiraProjectKey?: string;
+  slackChannel?: string;
 };
 
 export type ServiceCheck = {
@@ -43,7 +61,9 @@ export type CheckKeysEndpointResponse = {
     jira: ServiceCheck;
     slackBot: ServiceCheck;
     slackApp: ServiceCheck;
+    slackSocketMode: ServiceCheck;
   };
+  slackPing?: ServiceCheck;
 };
 
 export class CheckKeysEndpoint {
@@ -62,26 +82,41 @@ export class CheckKeysEndpoint {
   private async checkServices(
     input: CheckKeysEndpointInput
   ): Promise<CheckKeysEndpointResponse> {
-    const [github, jira, slackBot, slackApp] = await Promise.all([
+    const [
+      github,
+      jira,
+      slackBot,
+      slackApp,
+      slackSocketMode
+    ] = await Promise.all([
       this.checkGithub(),
       this.checkJira(input),
       this.checkSlackBot(),
-      this.checkSlackApp()
+      this.checkSlackApp(),
+      this.checkSlackSocketMode()
     ]);
+    const services = {
+      github,
+      jira,
+      slackBot,
+      slackApp,
+      slackSocketMode
+    };
+    const slackPing = this.isConfigured(input.slackChannel)
+      ? await this.sendSlackPing(input, services)
+      : undefined;
 
     return {
       ok:
         github.responding &&
         jira.responding &&
         slackBot.responding &&
-        slackApp.responding,
+        slackApp.responding &&
+        slackSocketMode.responding &&
+        (slackPing === undefined || slackPing.responding),
       jiraAuthType: this.dependencies.keychain.jiraAuthType,
-      services: {
-        github,
-        jira,
-        slackBot,
-        slackApp
-      }
+      services,
+      ...(slackPing === undefined ? {} : { slackPing })
     };
   }
 
@@ -143,6 +178,16 @@ export class CheckKeysEndpoint {
     );
   }
 
+  private async checkSlackSocketMode(): Promise<ServiceCheck> {
+    if (!this.isConfigured(this.dependencies.keychain.slackAppToken)) {
+      return this.missing('SLACK_APP_TOKEN');
+    }
+
+    return this.checkSlackAuth(() =>
+      this.dependencies.slackAppWebClient.apps.connections.open()
+    );
+  }
+
   private async checkService(
     check: () => Promise<unknown>
   ): Promise<ServiceCheck> {
@@ -170,6 +215,51 @@ export class CheckKeysEndpoint {
         throw new Error(response.error ?? 'Slack token rejected');
       }
     });
+  }
+
+  private async sendSlackPing(
+    input: CheckKeysEndpointInput,
+    services: CheckKeysEndpointResponse['services']
+  ): Promise<ServiceCheck> {
+    if (!services.slackBot.responding) {
+      return {
+        configured: true,
+        responding: false,
+        error: 'Slack bot check failed; ping was not sent'
+      };
+    }
+
+    return this.checkSlackAuth(() =>
+      this.dependencies.slackWebClient.chat.postMessage({
+        channel: input.slackChannel as string,
+        text: this.buildSlackPingMessage(input, services)
+      })
+    );
+  }
+
+  private buildSlackPingMessage(
+    input: CheckKeysEndpointInput,
+    services: CheckKeysEndpointResponse['services']
+  ): string {
+    return [
+      'Baroneza /checkKeys pong',
+      `jiraAuthType: ${this.dependencies.keychain.jiraAuthType}`,
+      `jiraProjectKey: ${input.jiraProjectKey ?? 'missing'}`,
+      `slackChannel: ${input.slackChannel ?? 'missing'}`,
+      `github: ${this.serviceStatus(services.github)}`,
+      `jira: ${this.serviceStatus(services.jira)}`,
+      `slackBot: ${this.serviceStatus(services.slackBot)}`,
+      `slackApp: ${this.serviceStatus(services.slackApp)}`,
+      `slackSocketMode: ${this.serviceStatus(services.slackSocketMode)}`
+    ].join('\n');
+  }
+
+  private serviceStatus(service: ServiceCheck): string {
+    if (!service.configured) {
+      return 'missing configuration';
+    }
+
+    return service.responding ? 'responding' : 'not responding';
   }
 
   private missingJiraKeys(): string[] {

--- a/swagger.json
+++ b/swagger.json
@@ -30,6 +30,16 @@
                             "type": "string",
                             "example": "ABC"
                         }
+                    },
+                    {
+                        "name": "slackChannel",
+                        "in": "query",
+                        "required": false,
+                        "description": "Optional Slack channel ID or name that receives a safe ping/pong status summary. Token values are never included.",
+                        "schema": {
+                            "type": "string",
+                            "example": "C1234567890"
+                        }
                     }
                 ],
                 "responses": {

--- a/tests/endpoints/check-keys-endpoint.test.ts
+++ b/tests/endpoints/check-keys-endpoint.test.ts
@@ -30,11 +30,22 @@ const dependencies = (
   slackWebClient: {
     auth: {
       test: jest.fn().mockResolvedValue({ ok: true })
+    },
+    chat: {
+      postMessage: jest.fn().mockResolvedValue({ ok: true })
     }
   },
   slackAppWebClient: {
     auth: {
       test: jest.fn().mockResolvedValue({ ok: true })
+    },
+    apps: {
+      connections: {
+        open: jest.fn().mockResolvedValue({
+          ok: true,
+          url: 'wss://socket-mode-url'
+        })
+      }
     }
   },
   ...overrides
@@ -55,6 +66,76 @@ describe('The check keys endpoint', () => {
         expect(response.services.jira.responding).toBe(true);
         expect(response.services.slackBot.responding).toBe(true);
         expect(response.services.slackApp.responding).toBe(true);
+        expect(response.services.slackSocketMode.responding).toBe(true);
+        done();
+      });
+  });
+
+  it('sends a safe Slack pong when a channel is provided', (done) => {
+    const postMessage = jest.fn().mockResolvedValue({ ok: true });
+
+    buildEndpoint(regularEnv, {
+      slackWebClient: {
+        auth: {
+          test: jest.fn().mockResolvedValue({ ok: true })
+        },
+        chat: {
+          postMessage
+        }
+      }
+    })
+      .execute({ jiraProjectKey: 'ABC', slackChannel: 'C123' })
+      .subscribe((response) => {
+        expect(response.ok).toBe(true);
+        expect(response.slackPing).toEqual({
+          configured: true,
+          responding: true
+        });
+        expect(postMessage).toHaveBeenCalledWith({
+          channel: 'C123',
+          text: expect.stringContaining('Baroneza /checkKeys pong')
+        });
+
+        const text = postMessage.mock.calls[0][0].text;
+        expect(text).toContain('jiraProjectKey: ABC');
+        expect(text).toContain('slackChannel: C123');
+        expect(text).toContain('slackSocketMode: responding');
+        expect(text).not.toContain('github-token');
+        expect(text).not.toContain('jira-token');
+        expect(text).not.toContain('slack-token');
+        expect(text).not.toContain('slack-app-token');
+        done();
+      });
+  });
+
+  it('reports Slack Socket Mode failures without returning the socket URL', (done) => {
+    const open = jest.fn().mockResolvedValue({
+      ok: false,
+      error: 'not_allowed_token_type',
+      url: 'wss://socket-mode-url'
+    });
+
+    buildEndpoint(regularEnv, {
+      slackAppWebClient: {
+        auth: {
+          test: jest.fn().mockResolvedValue({ ok: true })
+        },
+        apps: {
+          connections: {
+            open
+          }
+        }
+      }
+    })
+      .execute({ jiraProjectKey: 'ABC' })
+      .subscribe((response) => {
+        expect(response.ok).toBe(false);
+        expect(response.services.slackSocketMode).toEqual({
+          configured: true,
+          responding: false,
+          error: 'not_allowed_token_type'
+        });
+        expect(JSON.stringify(response)).not.toContain('wss://socket-mode-url');
         done();
       });
   });
@@ -108,6 +189,11 @@ describe('The check keys endpoint', () => {
         slackAppWebClient: {
           auth: {
             test: slackAppAuthTest
+          },
+          apps: {
+            connections: {
+              open: jest.fn().mockResolvedValue({ ok: true })
+            }
           }
         }
       }
@@ -154,6 +240,9 @@ describe('The check keys endpoint', () => {
           test: jest
             .fn()
             .mockResolvedValue({ ok: false, error: 'invalid_auth' })
+        },
+        chat: {
+          postMessage: jest.fn().mockResolvedValue({ ok: true })
         }
       }
     })


### PR DESCRIPTION
Adds an optional slackChannel query parameter to GET /checkKeys that posts a safe ping/pong status summary to Slack without including token values. Adds a separate Slack Socket Mode check using apps.connections.open so the app-level token and connections:write path are validated without exposing the generated WebSocket URL. Updates Swagger and endpoint tests for the Slack pong and Socket Mode failure behavior. Verified with npm run build, npm test -- --runInBand, focused endpoint tests, Swagger JSON parsing, and touched-file ESLint.